### PR TITLE
コマンドのexecuteメソッドをexecuteActionにリネームし、不要なパラメータを削除。ACommandクラスのtrimEndメソッドを削除し、デバッグ出力を追加

### DIFF
--- a/includes/ACommand.hpp
+++ b/includes/ACommand.hpp
@@ -21,7 +21,6 @@ class ACommand
 
 	private:
 		std::vector<std::string> _params;
-		static std::string trimEnd(const std::string& str);
 };
 
 #endif

--- a/includes/command/Invite.hpp
+++ b/includes/command/Invite.hpp
@@ -6,7 +6,7 @@
 class Invite : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/Join.hpp
+++ b/includes/command/Join.hpp
@@ -6,7 +6,7 @@
 class Join : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/Kick.hpp
+++ b/includes/command/Kick.hpp
@@ -6,7 +6,7 @@
 class Kick : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/Mode.hpp
+++ b/includes/command/Mode.hpp
@@ -6,7 +6,7 @@
 class Mode : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/Part.hpp
+++ b/includes/command/Part.hpp
@@ -6,7 +6,7 @@
 class Part : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/Ping.hpp
+++ b/includes/command/Ping.hpp
@@ -6,7 +6,7 @@
 class Ping : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/Pong.hpp
+++ b/includes/command/Pong.hpp
@@ -6,7 +6,7 @@
 class Pong : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/Privmsg.hpp
+++ b/includes/command/Privmsg.hpp
@@ -6,7 +6,7 @@
 class Privmsg : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/Quit.hpp
+++ b/includes/command/Quit.hpp
@@ -6,7 +6,7 @@
 class Quit : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/Topic.hpp
+++ b/includes/command/Topic.hpp
@@ -6,7 +6,7 @@
 class Topic : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/includes/command/User.hpp
+++ b/includes/command/User.hpp
@@ -6,7 +6,7 @@
 class User : public ACommand
 {
 	public:
-		void execute(Server& server, Client& client, int fd, const std::string& params);
+		void executeAction(Server& server, Client& client, int fd);
 };
 
 #endif

--- a/srcs/Command/ACommand.cpp
+++ b/srcs/Command/ACommand.cpp
@@ -1,4 +1,5 @@
 #include "ACommand.hpp"
+#include <iostream>
 
 void ACommand::execute(Server& server, Client& client, int fd, const std::string& params)
 {
@@ -9,24 +10,17 @@ void ACommand::execute(Server& server, Client& client, int fd, const std::string
 void ACommand::setParams(const std::string& params)
 {
 	_params.clear();
-	std::string trimmed = trimEnd(params);
-	std::istringstream ss(trimmed);
+	std::istringstream ss(params);
 	std::string token;
 	while (ss >> token)
 		_params.push_back(token);
+
+	//デバッグ出力用テスト
+	for (size_t i = 0; i < _params.size(); ++i)
+		std::cout << "params[" << i << "]=\"" << _params[i] << "\"" << std::endl;
 }
 
 const std::vector<std::string>& ACommand::params() const
 {
 	return _params;
-}
-
-std::string ACommand::trimEnd(const std::string& str)
-{
-	std::string trimmed = str;
-	if (!trimmed.empty() && trimmed.back() ==  '\n')		
-		trimmed.pop_back();
-	if (!trimmed.empty() && trimmed.back() ==  '\r')		
-		trimmed.pop_back();
-	return trimmed;
 }

--- a/srcs/Command/Invite.cpp
+++ b/srcs/Command/Invite.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Invite::execute(Server& server, Client& client, int fd, const std::string& params)
+void Invite::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement INVITE
 }

--- a/srcs/Command/Join.cpp
+++ b/srcs/Command/Join.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Join::execute(Server& server, Client& client, int fd, const std::string& params)
+void Join::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement JOIN
 }

--- a/srcs/Command/Kick.cpp
+++ b/srcs/Command/Kick.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Kick::execute(Server& server, Client& client, int fd, const std::string& params)
+void Kick::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement KICK
 }

--- a/srcs/Command/Mode.cpp
+++ b/srcs/Command/Mode.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Mode::execute(Server& server, Client& client, int fd, const std::string& params)
+void Mode::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement MODE
 }

--- a/srcs/Command/Nick.cpp
+++ b/srcs/Command/Nick.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Nick::execute(Server& server, Client& client, int fd, const std::string& params)
+void Nick::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement NICK
 }

--- a/srcs/Command/Part.cpp
+++ b/srcs/Command/Part.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Part::execute(Server& server, Client& client, int fd, const std::string& params)
+void Part::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement PART
 }

--- a/srcs/Command/Pass.cpp
+++ b/srcs/Command/Pass.cpp
@@ -5,8 +5,6 @@
 
 void Pass::executeAction(Server& server, Client& client, int fd)
 {
-	(void)fd;
-
 	if (params().size() <= 1)
 	{
 		server.sendError(client, fd, "461", "PASS :Not enough parameters");

--- a/srcs/Command/Ping.cpp
+++ b/srcs/Command/Ping.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Ping::execute(Server& server, Client& client, int fd, const std::string& params)
+void Ping::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement PING
 }

--- a/srcs/Command/Pong.cpp
+++ b/srcs/Command/Pong.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Pong::execute(Server& server, Client& client, int fd, const std::string& params)
+void Pong::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement PONG
 }

--- a/srcs/Command/Privmsg.cpp
+++ b/srcs/Command/Privmsg.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Privmsg::execute(Server& server, Client& client, int fd, const std::string& params)
+void Privmsg::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement PRIVMSG
 }

--- a/srcs/Command/Quit.cpp
+++ b/srcs/Command/Quit.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Quit::execute(Server& server, Client& client, int fd, const std::string& params)
+void Quit::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement QUIT
 }

--- a/srcs/Command/Topic.cpp
+++ b/srcs/Command/Topic.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void Topic::execute(Server& server, Client& client, int fd, const std::string& params)
+void Topic::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement TOPIC
 }

--- a/srcs/Command/User.cpp
+++ b/srcs/Command/User.cpp
@@ -2,11 +2,10 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-void User::execute(Server& server, Client& client, int fd, const std::string& params)
+void User::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	(void)params;
 	// TODO: implement USER
 }

--- a/srcs/Server/ServerUtils.cpp
+++ b/srcs/Server/ServerUtils.cpp
@@ -1,5 +1,5 @@
 #include "Server.hpp"
 bool Server::checkPassword(const std::string& pass) const
-{ 
-    return pass == _config.password(); 
+{
+    return pass == _config.password();
 }

--- a/srcs/commandTest.cpp
+++ b/srcs/commandTest.cpp
@@ -1,0 +1,43 @@
+#include "Config.hpp"
+#include "Server.hpp"
+#include "Client.hpp"
+#include "Pass.hpp"
+
+#include <iostream>
+
+void commandTest()
+{
+	std::cout << "tochi test" << std::endl;
+	ACommand* cmd = new Pass();
+	Config config("6667", "password");
+	Server server(config);
+	Client* client = new Client(0, "tochi");
+
+	cmd->execute(server, *client, 0, "Pass password\r\n");
+	std::cout << client->sendBuffer() << std::endl;
+	client->removeSentData(client->sendBuffer().length());
+
+	cmd->execute(server, *client, 0, "Pass \r\n");
+	std::cout << client->sendBuffer() << std::endl;
+	client->removeSentData(client->sendBuffer().length());
+
+	cmd->execute(server, *client, 0, "Pass pass word\r\n");
+	std::cout << client->sendBuffer() << std::endl;
+	client->removeSentData(client->sendBuffer().length());
+
+	// trim確認: \r\nあり・パスワード一致 → successなら trim OK、464なら \r が残っている
+	std::cout << "--- trim test ---" << std::endl;
+	cmd->execute(server, *client, 0, "Pass password\r\n");
+	std::string trimResult = client->sendBuffer();
+	client->removeSentData(trimResult.length());
+	if (trimResult.empty())
+		std::cout << "[OK] \\r trimmed correctly" << std::endl;
+	else
+		std::cout << "[NG] \\r not trimmed: " << trimResult << std::endl;
+
+	// 引数なし（スペースもない）→ 461
+	std::cout << "--- no arg test ---" << std::endl;
+	cmd->execute(server, *client, 0, "Pass\r\n");
+	std::cout << client->sendBuffer() << std::endl;
+	client->removeSentData(client->sendBuffer().length());
+}

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -3,47 +3,63 @@
 
 #include <iostream>
 
-int main(int argc, char** argv)
-{
-    if (argc != 3) 
-    {
-        std::cerr << "Usage: ircserv <port> <password>" << std::endl;
-        return 1;
-    }
+// int main(int argc, char** argv)
+// {
+//     if (argc != 3)
+//     {
+//         std::cerr << "Usage: ircserv <port> <password>" << std::endl;
+//         return 1;
+//     }
 
-	try
-	{
-		Config config(argv[1], argv[2]);
-		Server server(config);
-		server.run();
-	}
-	catch (const std::exception& e)
-	{
-		std::cerr << "Error: " << e.what() << std::endl;
-		return 1;
-	}
-	return 0;
-}
-
-// #include "Pass.hpp"
-// #include "Client.hpp"
-
-// int main(void){
-// 	std::cout << "tochi test" << std::endl;
-// 	ACommand* cmd = new Pass();
-// 	Config config("6667", "password");
-// 	Server server(config);
-// 	Client* client = new Client(0,"tochi");
-
-// 	cmd->execute(server,*client,0,"Pass password\r\n");
-// 	std::cout << client->sendBuffer() << std::endl;
-// 	client->removeSentData(client->sendBuffer().length());
-
-// 	cmd->execute(server,*client,0,"Pass \r\n");
-// 	std::cout << client->sendBuffer() << std::endl;
-// 	client->removeSentData(client->sendBuffer().length());
-	
-// 	cmd->execute(server,*client,0,"Pass pass word\r\n");
-// 	std::cout << client->sendBuffer() << std::endl;
-// 	client->removeSentData(client->sendBuffer().length());
+// 	try
+// 	{
+// 		Config config(argv[1], argv[2]);
+// 		Server server(config);
+// 		server.run();
+// 	}
+// 	catch (const std::exception& e)
+// 	{
+// 		std::cerr << "Error: " << e.what() << std::endl;
+// 		return 1;
+// 	}
+// 	return 0;
 // }
+
+#include "Pass.hpp"
+#include "Client.hpp"
+
+int main(void){
+	std::cout << "tochi test" << std::endl;
+	ACommand* cmd = new Pass();
+	Config config("6667", "password");
+	Server server(config);
+	Client* client = new Client(0,"tochi");
+
+	cmd->execute(server,*client,0,"Pass password\r\n");
+	std::cout << client->sendBuffer() << std::endl;
+	client->removeSentData(client->sendBuffer().length());
+
+	cmd->execute(server,*client,0,"Pass \r\n");
+	std::cout << client->sendBuffer() << std::endl;
+	client->removeSentData(client->sendBuffer().length());
+
+	cmd->execute(server,*client,0,"Pass pass word\r\n");
+	std::cout << client->sendBuffer() << std::endl;
+	client->removeSentData(client->sendBuffer().length());
+
+	// trim確認: \r\nあり・パスワード一致 → successなら trim OK、464なら \r が残っている
+	std::cout << "--- trim test ---" << std::endl;
+	cmd->execute(server,*client,0,"Pass password\r\n");
+	std::string trimResult = client->sendBuffer();
+	client->removeSentData(trimResult.length());
+	if (trimResult.empty())
+		std::cout << "[OK] \\r trimmed correctly" << std::endl;
+	else
+		std::cout << "[NG] \\r not trimmed: " << trimResult << std::endl;
+
+	// 引数なし（スペースもない）→ 461
+	std::cout << "--- no arg test ---" << std::endl;
+	cmd->execute(server,*client,0,"Pass\r\n");
+	std::cout << client->sendBuffer() << std::endl;
+	client->removeSentData(client->sendBuffer().length());
+}

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -3,63 +3,30 @@
 
 #include <iostream>
 
-// int main(int argc, char** argv)
-// {
-//     if (argc != 3)
-//     {
-//         std::cerr << "Usage: ircserv <port> <password>" << std::endl;
-//         return 1;
-//     }
+void commandTest();
 
-// 	try
-// 	{
-// 		Config config(argv[1], argv[2]);
-// 		Server server(config);
-// 		server.run();
-// 	}
-// 	catch (const std::exception& e)
-// 	{
-// 		std::cerr << "Error: " << e.what() << std::endl;
-// 		return 1;
-// 	}
-// 	return 0;
-// }
+static void ircserv(int argc, char** argv)
+{
+	if (argc != 3)
+	{
+		std::cerr << "Usage: ircserv <port> <password>" << std::endl;
+		return;
+	}
+	try
+	{
+		Config config(argv[1], argv[2]);
+		Server server(config);
+		server.run();
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "Error: " << e.what() << std::endl;
+	}
+}
 
-#include "Pass.hpp"
-#include "Client.hpp"
-
-int main(void){
-	std::cout << "tochi test" << std::endl;
-	ACommand* cmd = new Pass();
-	Config config("6667", "password");
-	Server server(config);
-	Client* client = new Client(0,"tochi");
-
-	cmd->execute(server,*client,0,"Pass password\r\n");
-	std::cout << client->sendBuffer() << std::endl;
-	client->removeSentData(client->sendBuffer().length());
-
-	cmd->execute(server,*client,0,"Pass \r\n");
-	std::cout << client->sendBuffer() << std::endl;
-	client->removeSentData(client->sendBuffer().length());
-
-	cmd->execute(server,*client,0,"Pass pass word\r\n");
-	std::cout << client->sendBuffer() << std::endl;
-	client->removeSentData(client->sendBuffer().length());
-
-	// trim確認: \r\nあり・パスワード一致 → successなら trim OK、464なら \r が残っている
-	std::cout << "--- trim test ---" << std::endl;
-	cmd->execute(server,*client,0,"Pass password\r\n");
-	std::string trimResult = client->sendBuffer();
-	client->removeSentData(trimResult.length());
-	if (trimResult.empty())
-		std::cout << "[OK] \\r trimmed correctly" << std::endl;
-	else
-		std::cout << "[NG] \\r not trimmed: " << trimResult << std::endl;
-
-	// 引数なし（スペースもない）→ 461
-	std::cout << "--- no arg test ---" << std::endl;
-	cmd->execute(server,*client,0,"Pass\r\n");
-	std::cout << client->sendBuffer() << std::endl;
-	client->removeSentData(client->sendBuffer().length());
+int main(int argc, char** argv)
+{
+	ircserv(argc, argv);
+	commandTest();
+	return 0;
 }


### PR DESCRIPTION
### 変更点

**1. Commandの実装をすべてexcuteActionに変更（Makefileでコンパイル通すため）
2. setParamsにparams確認用のデバッグ出力関数を追加
3. trimEnd関数の削除　それに伴い呼び出し側も変更**
```
std::string ACommand::trimEnd(const std::string& str)
{
	std::string trimmed = str;
	if (!trimmed.empty() && trimmed.back() ==  '\n')		
		trimmed.pop_back();
	if (!trimmed.empty() && trimmed.back() ==  '\r')		
		trimmed.pop_back();
	return trimmed;
}
```
```
void ACommand::setParams(const std::string& params)
{
	_params.clear();
	std::istringstream ss(params);
	std::string token;
	while (ss >> token)
		_params.push_back(token);

	//デバッグ出力用テスト
	for (size_t i = 0; i < _params.size(); ++i)
		std::cout << "params[" << i << "]=\"" << _params[i] << "\"" << std::endl;
}
```
→理由
・pop_back()が -std=c++98　に適合していなかった
・server側の関数で\r\nがすでにtrimできていた


修正後、テストして問題ないことを確認済み

```
takawagu@c3r5s3 ~/ft_irc (takawagu/pass_check)> ./ircserv
tochi test
params[0]="Pass"
params[1]="password"
success 

params[0]="Pass"
:ircserv 461 * PASS :Not enough parameters

params[0]="Pass"
params[1]="pass"
params[2]="word"
:ircserv 464 *  :Password incorrect

--- trim test ---
params[0]="Pass"
params[1]="password"
success 
[OK] \r trimmed correctly
--- no arg test ---
params[0]="Pass"
:ircserv 461 * PASS :Not enough parameters

Server shut down.
```