### PR TITLE
コマンドのパラメータを文字列からベクターに変更し、関連するメソッドを更新

### DIFF
--- a/includes/ACommand.hpp
+++ b/includes/ACommand.hpp
@@ -1,7 +1,6 @@
 #ifndef ACOMMAND_HPP
 #define ACOMMAND_HPP
 
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -12,14 +11,14 @@ class ACommand
 {
 	public:
 		virtual ~ACommand() {}
-		void execute(Server& server, Client& client, int fd,const std::string& params);
+		void execute(Server& server, Client& client, int fd, const std::vector<std::string>& params);
 		virtual void executeAction(Server& server, Client& client, int fd) = 0;
 
 	protected:
-		void setParams(const std::string& params);
 		const std::vector<std::string>& params() const;
 
 	private:
+		void setParams(const std::vector<std::string>& params);
 		std::vector<std::string> _params;
 };
 

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -39,6 +39,7 @@ class Server
 		bool isNicknameTaken(const std::string& nick) const;
 		std::string toScandanavianLower(const std::string& nick) const;
 		void addClient(int fd, Client* client);
+
 	private:
 		static volatile sig_atomic_t	_stop;
 		static void						signalHandler(int sig);
@@ -68,7 +69,7 @@ class Server
 
 		void		initCommandMap();
 		ACommand*	findInCmdMap(const std::string& command) const;
-		void		handleCommand(Client& client, int fd, const std::string& command, const std::string& params);
+		void		handleCommand(Client& client, int fd, const std::string& command, const std::vector<std::string>& params);
 
 		void	acceptNewClient();
 		int		acceptConnection(struct sockaddr_in& addr);
@@ -80,7 +81,7 @@ class Server
 		bool	isRecvSuccessful(ssize_t bytesReceived, int fd);
 		bool	isRecvBufferAvailable(Client& client, int fd);
 		void	processClientRequests(Client& client, int fd);
-		bool	parseRequest(const std::string& line, std::string& command, std::string& params);
+		bool	parseRequest(const std::string& line, std::string& command, std::vector<std::string>& params);
 		void	handleClientWrite(int fd);
 		bool	isSendSuccessful(ssize_t bytesSent, int fd);
 		void	deleteCommandMap();

--- a/srcs/Command/ACommand.cpp
+++ b/srcs/Command/ACommand.cpp
@@ -1,23 +1,14 @@
 #include "ACommand.hpp"
-#include <iostream>
 
-void ACommand::execute(Server& server, Client& client, int fd, const std::string& params)
+void ACommand::execute(Server& server, Client& client, int fd, const std::vector<std::string>& params)
 {
-    setParams(params);
-    executeAction(server, client, fd);
+	setParams(params);
+	executeAction(server, client, fd);
 }
 
-void ACommand::setParams(const std::string& params)
+void ACommand::setParams(const std::vector<std::string>& params)
 {
-	_params.clear();
-	std::istringstream ss(params);
-	std::string token;
-	while (ss >> token)
-		_params.push_back(token);
-
-	//デバッグ出力用テスト
-	for (size_t i = 0; i < _params.size(); ++i)
-		std::cout << "params[" << i << "]=\"" << _params[i] << "\"" << std::endl;
+	_params = params;
 }
 
 const std::vector<std::string>& ACommand::params() const

--- a/srcs/Command/Nick.cpp
+++ b/srcs/Command/Nick.cpp
@@ -4,23 +4,23 @@
 
 void Nick::executeAction(Server& server, Client& client, int fd)
 {
-	if (params().size() <= 1)
+	if (params().empty())
 	{
 		server.sendError(client, fd, "431", ":No nickname given");
 		return;
 	}
-	if (!isNicknameValid(params()[1]))
+	if (!isNicknameValid(params()[0]))
 	{
-		server.sendError(client, fd, "432", params()[1] + " :Erroneus nickname");
+		server.sendError(client, fd, "432", params()[0] + " :Erroneus nickname");
 		return;
 	}
-	if (server.isNicknameTaken(params()[1]))
+	if (server.isNicknameTaken(params()[0]))
 	{
-		server.sendError(client, fd, "433", params()[1] + " :Nickname is already in use");
+		server.sendError(client, fd, "433", params()[0] + " :Nickname is already in use");
 		return;
 	}
 	std::string old_nick = client.nickname();
-	client.setNickname(params()[1]);
+	client.setNickname(params()[0]);
 	client.appendToSendBuffer(":" + old_nick + " NICK " + client.nickname() + "\r\n");
 	client.tryRegister();
 	return;

--- a/srcs/Command/Pass.cpp
+++ b/srcs/Command/Pass.cpp
@@ -9,12 +9,12 @@ void Pass::executeAction(Server& server, Client& client, int fd)
 		server.sendError(client, fd, "462", " :You may not reregister");
 		return;
 	}
-	if (params().size() <= 1)
+	if (params().empty())
 	{
 		server.sendError(client, fd, "461", "PASS :Not enough parameters");
 		return;
 	}
-	if (!server.checkPassword(params()[1]))
+	if (!server.checkPassword(params()[0]))
 	{
 		server.sendError(client, fd, "464", " :Password incorrect");
 		return;

--- a/srcs/Server/ServerCommand.cpp
+++ b/srcs/Server/ServerCommand.cpp
@@ -7,9 +7,8 @@
 
 static bool isAllowedBeforeRegistration(const std::string& command);
 static std::string extractCommand(const std::string& line, std::string::size_type& pos);
-static std::string extractParams(const std::string& line, std::string::size_type pos);
+static void parseParams(const std::string& line, std::string::size_type pos, std::vector<std::string>& params);
 static void skipSpaces(const std::string& line, std::string::size_type& pos);
-static std::string::size_type findCmdEnd(const std::string& line, std::string::size_type pos);
 
 
 void Server::initCommandMap()
@@ -29,7 +28,7 @@ void Server::initCommandMap()
 	_cmd_map["PART"]    = new Part();
 }
 
-void Server::handleCommand(Client& client, int fd, const std::string& command, const std::string& params)
+void Server::handleCommand(Client& client, int fd, const std::string& command, const std::vector<std::string>& params)
 {
 	ACommand* cmd = findInCmdMap(command);
 	if (cmd == NULL)
@@ -62,7 +61,7 @@ void Server::deleteCommandMap()
 	_cmd_map.clear();
 }
 
-bool Server::parseRequest(const std::string& line, std::string& command, std::string& params)
+bool Server::parseRequest(const std::string& line, std::string& command, std::vector<std::string>& params)
 {
 	std::cout << ">> " << line << std::endl;
 
@@ -71,7 +70,8 @@ bool Server::parseRequest(const std::string& line, std::string& command, std::st
 	if (command.empty())
 		return false;
 
-	params = extractParams(line, pos);
+	params.clear();
+	parseParams(line, pos, params);
 	return true;
 }
 
@@ -81,26 +81,38 @@ static std::string extractCommand(const std::string& line, std::string::size_typ
 	if (pos == line.size())
 		return std::string();
 
-	std::string::size_type cmd_end = findCmdEnd(line, pos);
-	std::string command = line.substr(pos, cmd_end - pos);
-	pos = cmd_end;
+	std::string::size_type end = line.find(' ', pos);
+	if (end == std::string::npos)
+		end = line.size();
+
+	std::string command = line.substr(pos, end - pos);
+	pos = end;
 	return command;
 }
 
-static std::string::size_type findCmdEnd(const std::string& line, std::string::size_type pos)
+// IRC RFC 準拠: ':' で始まるトークンはそれ以降を trailing として1つのパラメータにまとめる
+static void parseParams(const std::string& line, std::string::size_type pos, std::vector<std::string>& params)
 {
-	std::string::size_type end = line.find(' ', pos);
-	if (end == std::string::npos)
-		return line.size();
-	return end;
-}
+	while (pos < line.size())
+	{
+		skipSpaces(line, pos);
+		if (pos >= line.size())
+			break;
 
-static std::string extractParams(const std::string& line, std::string::size_type pos)
-{
-	skipSpaces(line, pos);
-	return line.substr(pos);
-}
+		if (line[pos] == ':')
+		{
+			params.push_back(line.substr(pos + 1));
+			break;
+		}
 
+		std::string::size_type end = line.find(' ', pos);
+		if (end == std::string::npos)
+			end = line.size();
+
+		params.push_back(line.substr(pos, end - pos));
+		pos = end;
+	}
+}
 
 static void skipSpaces(const std::string& line, std::string::size_type& pos)
 {

--- a/srcs/Server/ServerIn.cpp
+++ b/srcs/Server/ServerIn.cpp
@@ -62,7 +62,7 @@ void Server::processClientRequests(Client& client, int fd)
 	while (client.extractLine(line))
 	{
 		std::string command;
-		std::string params;
+		std::vector<std::string> params;
 		if (parseRequest(line, command, params))
 			handleCommand(client, fd, command, params);
 	}

--- a/srcs/commandTest.cpp
+++ b/srcs/commandTest.cpp
@@ -10,6 +10,26 @@ void PassTest();
 void trimTest();
 void NickTest();
 
+static std::vector<std::string> makeParams()
+{
+	return std::vector<std::string>();
+}
+
+static std::vector<std::string> makeParams(const std::string& a)
+{
+	std::vector<std::string> v;
+	v.push_back(a);
+	return v;
+}
+
+static std::vector<std::string> makeParams(const std::string& a, const std::string& b)
+{
+	std::vector<std::string> v;
+	v.push_back(a);
+	v.push_back(b);
+	return v;
+}
+
 void commandTest()
 {
 	// trimTest();
@@ -24,15 +44,15 @@ void PassTest(){
 	Server server(config);
 	Client* client = new Client(0, "tochi");
 
-	cmd->execute(server, *client, 0, "Pass password\r\n");
+	cmd->execute(server, *client, 0, makeParams("password"));
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
 
-	cmd->execute(server, *client, 0, "Pass \r\n");
+	cmd->execute(server, *client, 0, makeParams());
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
 
-	cmd->execute(server, *client, 0, "Pass pass word\r\n");
+	cmd->execute(server, *client, 0, makeParams("pass", "word"));
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
 }
@@ -45,33 +65,33 @@ void NickTest(){
 	Client* client = new Client(0, "tochi");
 	server.addClient(0, client);
 
-	cmd->execute(server, *client, 0, "Nick\r\n");
+	cmd->execute(server, *client, 0, makeParams());
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
 
-	cmd->execute(server, *client, 0, "Nick tochi\r\n");
+	cmd->execute(server, *client, 0, makeParams("tochi"));
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
 
 	//　first char is only letter
-	cmd->execute(server, *client, 0, "Nick 123number\r\n");
+	cmd->execute(server, *client, 0, makeParams("123number"));
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
 
 	// ! is not allowed
-	cmd->execute(server, *client, 0, "Nick tochi!\r\n");
+	cmd->execute(server, *client, 0, makeParams("tochi!"));
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
 
 	// length <= 9
-	cmd->execute(server, *client, 0, "Nick T123456789\r\n");
+	cmd->execute(server, *client, 0, makeParams("T123456789"));
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
 
 	// same nickname is not allowed
 	Client* client2 = new Client(1, "tochi2");
 	server.addClient(1, client2);
-	cmd->execute(server, *client2, 0, "Nick tochi\r\n");
+	cmd->execute(server, *client2, 0, makeParams("tochi"));
 	std::cout << client2->sendBuffer() << std::endl;
 	client2->removeSentData(client2->sendBuffer().length());
 
@@ -81,7 +101,7 @@ void NickTest(){
 	// case-insensitive: Tochi == tochi
 	Client* client3 = new Client(2, "tochi3");
 	server.addClient(2, client3);
-	cmd->execute(server, *client3, 2, "Nick Tochi\r\n");
+	cmd->execute(server, *client3, 2, makeParams("Tochi"));
 	std::cout << client3->sendBuffer() << std::endl;
 	client3->removeSentData(client3->sendBuffer().length());
 	std::cout << "Client 3 nickname: " << client3->nickname() << std::endl;
@@ -89,14 +109,14 @@ void NickTest(){
 	// scandinavian: T{} == T[]
 	Client* client4 = new Client(3, "tochi4");
 	server.addClient(3, client4);
-	cmd->execute(server, *client4, 3, "Nick T[]\r\n");
+	cmd->execute(server, *client4, 3, makeParams("T[]"));
 	std::cout << client4->sendBuffer() << std::endl;
 	client4->removeSentData(client4->sendBuffer().length());
 	std::cout << "Client 4 nickname: " << client4->nickname() << std::endl;
 
 	Client* client5 = new Client(4, "tochi5");
 	server.addClient(4, client5);
-	cmd->execute(server, *client5, 4, "Nick T{}\r\n");
+	cmd->execute(server, *client5, 4, makeParams("T{}"));
 	std::cout << client5->sendBuffer() << std::endl;
 	client5->removeSentData(client5->sendBuffer().length());
 	std::cout << "Client 5 nickname: " << client5->nickname() << std::endl;
@@ -109,9 +129,8 @@ void trimTest(){
 	Server server(config);
 	Client* client = new Client(0, "tochi");
 
-	// trim確認: \r\nあり・パスワード一致 → successなら trim OK、464なら \r が残っている
 	std::cout << "--- trim test ---" << std::endl;
-	cmd->execute(server, *client, 0, "Pass password\r\n");
+	cmd->execute(server, *client, 0, makeParams("password"));
 	std::string trimResult = client->sendBuffer();
 	client->removeSentData(trimResult.length());
 	if (trimResult.empty())
@@ -119,9 +138,8 @@ void trimTest(){
 	else
 		std::cout << "[NG] \\r not trimmed: " << trimResult << std::endl;
 
-	// 引数なし（スペースもない）→ 461
 	std::cout << "--- no arg test ---" << std::endl;
-	cmd->execute(server, *client, 0, "Pass\r\n");
+	cmd->execute(server, *client, 0, makeParams());
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
 }


### PR DESCRIPTION
## 変更概要


### 目的
IRCの trailing param (:real name with spaces) をコマンドが正しく受け取れるよう、パラメータの解析責務を整理した。

### 変更前の問題

setParams が istringstream >> でスペース分割する
 → :real name が複数トークンに壊れる

テストはフルライン ("Nick tochi\r\n") を渡すが、実サーバーはコマンド名を除いた文字列を渡す
 → params()[0] / params()[1] のインデックスが食い違っていた


### 変更内容
[ServerCommand.cpp](vscode-webview://0ekr1lomog0aqn2r3kjcj06ghbd8gl2kjp3usdea7tigqbfkuhaf/srcs/Server/ServerCommand.cpp)
parseRequest に IRC パース処理を集約。: を検出したらそれ以降を1トークンにまとめる。

[ACommand.hpp](vscode-webview://0ekr1lomog0aqn2r3kjcj06ghbd8gl2kjp3usdea7tigqbfkuhaf/includes/ACommand.hpp) / [ACommand.cpp](vscode-webview://0ekr1lomog0aqn2r3kjcj06ghbd8gl2kjp3usdea7tigqbfkuhaf/srcs/Command/ACommand.cpp)
execute / setParams のシグネチャを string → vector<string> に変更。パース処理を完全に除去。

[Server.hpp](vscode-webview://0ekr1lomog0aqn2r3kjcj06ghbd8gl2kjp3usdea7tigqbfkuhaf/includes/Server.hpp)
parseRequest / handleCommand のシグネチャを vector<string> に変更。

[ServerIn.cpp](vscode-webview://0ekr1lomog0aqn2r3kjcj06ghbd8gl2kjp3usdea7tigqbfkuhaf/srcs/Server/ServerIn.cpp)
params の型を string → vector<string> に変更。

[Nick.cpp](vscode-webview://0ekr1lomog0aqn2r3kjcj06ghbd8gl2kjp3usdea7tigqbfkuhaf/srcs/Command/Nick.cpp) / [Pass.cpp](vscode-webview://0ekr1lomog0aqn2r3kjcj06ghbd8gl2kjp3usdea7tigqbfkuhaf/srcs/Command/Pass.cpp)
params()[1] → params()[0]、size() <= 1 → empty() に修正。

[commandTest.cpp](vscode-webview://0ekr1lomog0aqn2r3kjcj06ghbd8gl2kjp3usdea7tigqbfkuhaf/srcs/commandTest.cpp)
C++98 対応の makeParams() ヘルパーを追加し、vector を直接渡す形に変更。