### PR TITLE
Joinコマンドの実装とテストを追加

### DIFF
--- a/includes/ACommand.hpp
+++ b/includes/ACommand.hpp
@@ -22,4 +22,7 @@ class ACommand
 		std::vector<std::string> _params;
 };
 
+// utils
+std::vector<std::string> splitByComma(const std::string& str);
+
 #endif

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -14,6 +14,7 @@ class Client
 
 		int					fd() const;
 		const std::string&	hostname() const;
+		std::string			prefix() const;
 
 		const std::string&	nickname() const;
 		void				setNickname(const std::string& nick);

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -28,6 +28,11 @@ const std::string& Client::hostname() const
 	return _hostname;
 }
 
+std::string Client::prefix() const
+{
+	return _nickname + "!" + _username + "@" + _hostname;
+}
+
 const std::string& Client::nickname() const
 {
 	return _nickname;

--- a/srcs/Command/Join.cpp
+++ b/srcs/Command/Join.cpp
@@ -4,7 +4,6 @@
 #include "Channel.hpp"
 
 static bool isChannelNameValid(const std::string& name);
-static std::vector<std::string> splitByComma(const std::string& str);
 static void expandChannelsAndKeys(const std::vector<std::string>& params, std::vector<std::string>& channels, std::vector<std::string>& keys);
 static bool isJoinBlocked(Server& server, Client& client, int fd, Channel* channel, const std::string& channelName, const std::string& key);
 static Channel* addClientToChannel(Server& server, Client& client, const std::string& channelName, bool isNewChannel);
@@ -149,24 +148,4 @@ static void expandChannelsAndKeys(const std::vector<std::string>& params, std::v
 	channels = splitByComma(params[0]);
 	if (params.size() >= 2)
 		keys = splitByComma(params[1]);
-}
-
-static std::vector<std::string> splitByComma(const std::string& str)
-{
-	std::vector<std::string> result;
-	std::string current;
-	for (size_t i = 0; i < str.length(); i++)
-	{
-		if (str[i] == ',')
-		{
-			if (!current.empty())
-				result.push_back(current);
-			current.clear();
-		}
-		else
-			current += str[i];
-	}
-	if (!current.empty())
-		result.push_back(current);
-	return result;
 }

--- a/srcs/Command/Join.cpp
+++ b/srcs/Command/Join.cpp
@@ -1,11 +1,172 @@
 #include "Join.hpp"
 #include "Server.hpp"
 #include "Client.hpp"
+#include "Channel.hpp"
+
+static bool isChannelNameValid(const std::string& name);
+static std::vector<std::string> splitByComma(const std::string& str);
+static void expandChannelsAndKeys(const std::vector<std::string>& params, std::vector<std::string>& channels, std::vector<std::string>& keys);
+static bool isJoinBlocked(Server& server, Client& client, int fd, Channel* channel, const std::string& channelName, const std::string& key);
+static Channel* addClientToChannel(Server& server, Client& client, const std::string& channelName, bool isNewChannel);
+static void sendJoinReplies(Server& server, Client& client, int fd, Channel* channel, const std::string& channelName);
+static void broadcastJoin(Server& server, Client& client, Channel* channel, const std::string& channelName);
+static void sendTopic(Client& client, Channel* channel, const std::string& channelName);
+static void sendNamesList(Client& client, Channel* channel, const std::string& channelName);
+static void joinOneChannel(Server& server, Client& client, int fd, const std::string& channelName, const std::string& key);
 
 void Join::executeAction(Server& server, Client& client, int fd)
 {
-	(void)server;
-	(void)client;
-	(void)fd;
-	// TODO: implement JOIN
+	if (params().empty())
+	{
+		server.sendError(client, fd, "461", "JOIN :Not enough parameters");
+		return;
+	}
+
+	std::vector<std::string> channels;
+	std::vector<std::string> keys;
+	expandChannelsAndKeys(params(), channels, keys);
+
+	for (size_t i = 0; i < channels.size(); i++)
+	{
+		std::string key;
+		if (i < keys.size())
+			key = keys[i];
+		joinOneChannel(server, client, fd, channels[i], key);
+	}
+}
+
+static void joinOneChannel(Server& server, Client& client, int fd, const std::string& channelName, const std::string& key)
+{
+	if (!isChannelNameValid(channelName))
+	{
+		server.sendError(client, fd, "403", channelName + " :No such channel");
+		return;
+	}
+
+	Channel* channel = server.findChannel(channelName);
+	bool isNewChannel = (channel == NULL);
+
+	if (!isNewChannel && isJoinBlocked(server, client, fd, channel, channelName, key))
+		return;
+
+	channel = addClientToChannel(server, client, channelName, isNewChannel);
+	sendJoinReplies(server, client, fd, channel, channelName);
+}
+
+static bool isJoinBlocked(Server& server, Client& client, int fd, Channel* channel, const std::string& channelName, const std::string& key)
+{
+	if (channel->hasMember(&client))
+		return true;
+	if (channel->isInviteOnly() && !channel->isInvited(client.nickname()))
+	{
+		server.sendError(client, fd, "473", channelName + " :Cannot join channel (+i)");
+		return true;
+	}
+	if (!channel->key().empty() && channel->key() != key)
+	{
+		server.sendError(client, fd, "475", channelName + " :Cannot join channel (+k)");
+		return true;
+	}
+	if (channel->userLimit() > 0 && channel->memberCount() >= channel->userLimit())
+	{
+		server.sendError(client, fd, "471", channelName + " :Cannot join channel (+l)");
+		return true;
+	}
+	return false;
+}
+
+static Channel* addClientToChannel(Server& server, Client& client, const std::string& channelName, bool isNewChannel)
+{
+	Channel* channel = server.getOrCreateChannel(channelName);
+	channel->addMember(&client, isNewChannel);
+	client.joinChannel(channelName);
+	if (channel->isInvited(client.nickname()))
+		channel->removeInvite(client.nickname());
+	return channel;
+}
+
+static void sendJoinReplies(Server& server, Client& client, int fd, Channel* channel, const std::string& channelName)
+{
+	broadcastJoin(server, client, channel, channelName);
+	sendTopic(client, channel, channelName);
+	sendNamesList(client, channel, channelName);
+	server.setPollout(fd, true);
+}
+
+static void broadcastJoin(Server& server, Client& client, Channel* channel, const std::string& channelName)
+{
+	std::string joinMsg = ":" + client.prefix() + " JOIN " + channelName + "\r\n";
+	server.broadcastToChannel(channel, joinMsg);
+}
+
+static void sendTopic(Client& client, Channel* channel, const std::string& channelName)
+{
+	if (!channel->topic().empty())
+	{
+		std::string topicReply = ":ircserv 332 " + client.nickname() + " " + channelName + " :" + channel->topic() + "\r\n";
+		client.appendToSendBuffer(topicReply);
+	}
+	else
+	{
+		std::string noTopicReply = ":ircserv 331 " + client.nickname() + " " + channelName + " :No topic is set\r\n";
+		client.appendToSendBuffer(noTopicReply);
+	}
+}
+
+static void sendNamesList(Client& client, Channel* channel, const std::string& channelName)
+{
+	std::string namesList = ":ircserv 353 " + client.nickname() + " = " + channelName + " :";
+	const std::map<Client*, bool>& members = channel->members();
+	for (std::map<Client*, bool>::const_iterator it = members.begin(); it != members.end(); ++it)
+	{
+		if (it != members.begin())
+			namesList += " ";
+		if (it->second)
+			namesList += "@";
+		namesList += it->first->nickname();
+	}
+	namesList += "\r\n";
+	client.appendToSendBuffer(namesList);
+
+	std::string endOfNames = ":ircserv 366 " + client.nickname() + " " + channelName + " :End of /NAMES list\r\n";
+	client.appendToSendBuffer(endOfNames);
+}
+
+static bool isChannelNameValid(const std::string& name)
+{
+	if (name.empty() || name[0] != '#' || name.length() < 2)
+		return false;
+	for (size_t i = 1; i < name.length(); i++)
+	{
+		if (name[i] == ' ' || name[i] == ',' || name[i] == '\0')
+			return false;
+	}
+	return true;
+}
+
+static void expandChannelsAndKeys(const std::vector<std::string>& params, std::vector<std::string>& channels, std::vector<std::string>& keys)
+{
+	channels = splitByComma(params[0]);
+	if (params.size() >= 2)
+		keys = splitByComma(params[1]);
+}
+
+static std::vector<std::string> splitByComma(const std::string& str)
+{
+	std::vector<std::string> result;
+	std::string current;
+	for (size_t i = 0; i < str.length(); i++)
+	{
+		if (str[i] == ',')
+		{
+			if (!current.empty())
+				result.push_back(current);
+			current.clear();
+		}
+		else
+			current += str[i];
+	}
+	if (!current.empty())
+		result.push_back(current);
+	return result;
 }

--- a/srcs/Command/User.cpp
+++ b/srcs/Command/User.cpp
@@ -31,6 +31,6 @@ void User::executeAction(Server& server, Client& client, int fd)
 
 static void sendWelcomeMessage(Client& client)
 {
-	std::string welcome_msg = client.nickname() + " :Welcome to the Internet Relay Network " + client.nickname() + "!" + client.username() + "@" + client.hostname() + "\r\n";
+	std::string welcome_msg = client.nickname() + " :Welcome to the Internet Relay Network " + client.prefix() + "\r\n";
 	client.appendToSendBuffer(welcome_msg);
 }

--- a/srcs/Command/Utils/splitByComma.cpp
+++ b/srcs/Command/Utils/splitByComma.cpp
@@ -1,0 +1,21 @@
+#include "ACommand.hpp"
+
+std::vector<std::string> splitByComma(const std::string& str)
+{
+	std::vector<std::string> result;
+	std::string current;
+	for (size_t i = 0; i < str.length(); i++)
+	{
+		if (str[i] == ',')
+		{
+			if (!current.empty())
+				result.push_back(current);
+			current.clear();
+		}
+		else
+			current += str[i];
+	}
+	if (!current.empty())
+		result.push_back(current);
+	return result;
+}

--- a/srcs/Server/ServerLoop.cpp
+++ b/srcs/Server/ServerLoop.cpp
@@ -23,12 +23,11 @@ void Server::loop()
 void Server::waitForEvents()
 {
 	int ready = -1;
-	bool unrecoverableError = (ready < 0 && errno != EINTR);
 
 	while (ready < 0)
 	{
 		ready = poll(&_pfds[0], _pfds.size(), -1);
-		if (unrecoverableError)
+		if (ready < 0 && errno != EINTR)
 			throw std::runtime_error("poll: " + std::string(std::strerror(errno)));
 	}
 }

--- a/srcs/commandTest.cpp
+++ b/srcs/commandTest.cpp
@@ -1,9 +1,11 @@
 #include "Config.hpp"
 #include "Server.hpp"
 #include "Client.hpp"
+#include "Channel.hpp"
 #include "Pass.hpp"
 #include "Nick.hpp"
 #include "User.hpp"
+#include "Join.hpp"
 
 #include <iostream>
 
@@ -11,6 +13,7 @@ void PassTest();
 void trimTest();
 void NickTest();
 void RegisterTest();
+void JoinTest();
 
 static std::vector<std::string> makeParams()
 {
@@ -47,7 +50,8 @@ void commandTest()
 	// trimTest();
 	// PassTest();
 	// NickTest();
-	RegisterTest();
+	// RegisterTest();
+	JoinTest();
 }
 
 void PassTest(){
@@ -155,6 +159,292 @@ void RegisterTest(){
 	user_cmd->execute(server, *client, 0, makeParams("tomo", "0", "*", "Tomo Ka"));
 	std::cout << client->sendBuffer() << std::endl;
 	client->removeSentData(client->sendBuffer().length());
+}
+
+static Client* makeRegisteredClient(Server& server, int fd, const std::string& nick)
+{
+	Client* client = new Client(fd, "localhost");
+	server.addClient(fd, client);
+
+	ACommand* pass = new Pass();
+	pass->execute(server, *client, fd, makeParams("password"));
+	client->removeSentData(client->sendBuffer().length());
+	delete pass;
+
+	ACommand* nick_cmd = new Nick();
+	nick_cmd->execute(server, *client, fd, makeParams(nick));
+	client->removeSentData(client->sendBuffer().length());
+	delete nick_cmd;
+
+	ACommand* user_cmd = new User();
+	user_cmd->execute(server, *client, fd, makeParams("user1", "0", "*", "Real Name"));
+	client->removeSentData(client->sendBuffer().length());
+	delete user_cmd;
+
+	return client;
+}
+
+static void printAndFlush(Client* client, const std::string& label)
+{
+	std::cout << "[" << label << "] " << client->sendBuffer();
+	client->removeSentData(client->sendBuffer().length());
+}
+
+void JoinTest()
+{
+	std::cout << "<<Join test>>" << std::endl;
+	Config config("6667", "password");
+	ACommand* join = new Join();
+
+	// パラメータなし → 461 Not enough parameters
+	{
+		std::cout << "-- no params --" << std::endl;
+		Server server(config);
+		Client* client = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *client, 100, makeParams());
+		printAndFlush(client, "461 expected");
+	}
+
+	// 無効なチャンネル名（#なし）→ 403 No such channel
+	{
+		std::cout << "-- invalid channel name (no #) --" << std::endl;
+		Server server(config);
+		Client* client = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *client, 100, makeParams("nochannel"));
+		printAndFlush(client, "403 expected");
+	}
+
+	// 無効なチャンネル名（#のみ）→ 403 No such channel
+	{
+		std::cout << "-- invalid channel name (# only) --" << std::endl;
+		Server server(config);
+		Client* client = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *client, 100, makeParams("#"));
+		printAndFlush(client, "403 expected");
+	}
+
+	// 正常JOIN（トピックなし）→ JOIN + 331 + 353 + 366
+	{
+		std::cout << "-- normal join (no topic) --" << std::endl;
+		Server server(config);
+		Client* client = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *client, 100, makeParams("#general"));
+		printAndFlush(client, "JOIN+331+353+366 expected");
+	}
+
+	// 正常JOIN（トピックあり）→ JOIN + 332 + 353 + 366
+	{
+		std::cout << "-- normal join (with topic) --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#general"));
+		alice->removeSentData(alice->sendBuffer().length());
+		Channel* ch = server.findChannel("#general");
+		ch->setTopic("hello world", "alice");
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#general"));
+		printAndFlush(bob, "JOIN+332+353+366 expected");
+	}
+
+	// すでに参加済み → 何も送信されない
+	{
+		std::cout << "-- already joined --" << std::endl;
+		Server server(config);
+		Client* client = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *client, 100, makeParams("#general"));
+		client->removeSentData(client->sendBuffer().length());
+		join->execute(server, *client, 100, makeParams("#general"));
+		std::string buf = client->sendBuffer();
+		if (buf.empty())
+			std::cout << "[already joined] OK: no message sent" << std::endl;
+		else
+			std::cout << "[already joined] NG: " << buf;
+		client->removeSentData(buf.length());
+	}
+
+	// invite-only + 招待なし → 473
+	{
+		std::cout << "-- invite-only, not invited --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#secret"));
+		alice->removeSentData(alice->sendBuffer().length());
+		Channel* ch = server.findChannel("#secret");
+		ch->setInviteOnly(true);
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#secret"));
+		printAndFlush(bob, "473 expected");
+	}
+
+	// invite-only + 招待あり → 正常JOIN
+	{
+		std::cout << "-- invite-only, invited --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#secret"));
+		alice->removeSentData(alice->sendBuffer().length());
+		Channel* ch = server.findChannel("#secret");
+		ch->setInviteOnly(true);
+		ch->addInvite("bob");
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#secret"));
+		printAndFlush(bob, "JOIN expected");
+	}
+
+	// キー違い → 475
+	{
+		std::cout << "-- wrong key --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#keyed"));
+		alice->removeSentData(alice->sendBuffer().length());
+		Channel* ch = server.findChannel("#keyed");
+		ch->setKey("secret");
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#keyed", "wrong"));
+		printAndFlush(bob, "475 expected");
+	}
+
+	// キー正しい → 正常JOIN
+	{
+		std::cout << "-- correct key --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#keyed"));
+		alice->removeSentData(alice->sendBuffer().length());
+		Channel* ch = server.findChannel("#keyed");
+		ch->setKey("secret");
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#keyed", "secret"));
+		printAndFlush(bob, "JOIN expected");
+	}
+
+	// ユーザーリミット超過 → 471
+	{
+		std::cout << "-- user limit exceeded --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#limited"));
+		alice->removeSentData(alice->sendBuffer().length());
+		Channel* ch = server.findChannel("#limited");
+		ch->setUserLimit(1);
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#limited"));
+		printAndFlush(bob, "471 expected");
+	}
+
+	// 複数チャンネルへの同時JOIN
+	{
+		std::cout << "-- multi channel join --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#chan1,#chan2,#chan3"));
+		printAndFlush(alice, "3x JOIN expected");
+	}
+
+	// 複数チャンネル + 対応するキー
+	{
+		std::cout << "-- multi channel join with keys --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#a,#b"));
+		alice->removeSentData(alice->sendBuffer().length());
+		server.findChannel("#a")->setKey("ka");
+		server.findChannel("#b")->setKey("kb");
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#a,#b", "ka,kb"));
+		printAndFlush(bob, "2x JOIN expected");
+	}
+
+	// JOINしたとき他のメンバーにブロードキャストされる
+	{
+		std::cout << "-- broadcast to existing members --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#general"));
+		alice->removeSentData(alice->sendBuffer().length());
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#general"));
+		std::string aliceBuf = alice->sendBuffer();
+		if (aliceBuf.find("bob") != std::string::npos)
+			std::cout << "[broadcast] OK: alice received bob's JOIN" << std::endl;
+		else
+			std::cout << "[broadcast] NG: alice did not receive bob's JOIN" << std::endl;
+		alice->removeSentData(aliceBuf.length());
+	}
+
+	// #以外のプレフィックス → 403 No such channel
+	{
+		std::cout << "-- invalid prefix (&channel) --" << std::endl;
+		Server server(config);
+		Client* client = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *client, 100, makeParams("&general"));
+		printAndFlush(client, "403 expected");
+	}
+
+	// チャンネル名にスペース → 403 No such channel
+	{
+		std::cout << "-- channel name with space --" << std::endl;
+		Server server(config);
+		Client* client = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *client, 100, makeParams("#chan nel"));
+		printAndFlush(client, "403 expected");
+	}
+
+	// invite-only: JOIN後にinvite-listから削除される → 再JOINは通常どおり弾かれる
+	{
+		std::cout << "-- invite removed after join --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#secret"));
+		alice->removeSentData(alice->sendBuffer().length());
+		Channel* ch = server.findChannel("#secret");
+		ch->setInviteOnly(true);
+		ch->addInvite("bob");
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#secret"));
+		bob->removeSentData(bob->sendBuffer().length());
+
+		if (!ch->isInvited("bob"))
+			std::cout << "[invite removed] OK: invite cleared after join" << std::endl;
+		else
+			std::cout << "[invite removed] NG: invite still present after join" << std::endl;
+	}
+
+	// キー数がチャンネル数より少ない → 不足分は空文字キーで照合
+	{
+		std::cout << "-- fewer keys than channels --" << std::endl;
+		Server server(config);
+		Client* alice = makeRegisteredClient(server, 100, "alice");
+		join->execute(server, *alice, 100, makeParams("#a,#b"));
+		alice->removeSentData(alice->sendBuffer().length());
+		server.findChannel("#a")->setKey("ka");
+		server.findChannel("#b")->setKey("kb");
+
+		Client* bob = makeRegisteredClient(server, 101, "bob");
+		join->execute(server, *bob, 101, makeParams("#a,#b", "ka"));
+		std::string buf = bob->sendBuffer();
+		if (buf.find(":bob!user1@localhost JOIN #a") != std::string::npos)
+			std::cout << "[fewer keys] OK: joined #a with correct key" << std::endl;
+		else
+			std::cout << "[fewer keys] NG: did not join #a" << std::endl;
+		if (buf.find("475") != std::string::npos)
+			std::cout << "[fewer keys] OK: blocked from #b (missing key)" << std::endl;
+		else
+			std::cout << "[fewer keys] NG: should have been blocked from #b" << std::endl;
+		bob->removeSentData(buf.length());
+	}
+
+	delete join;
 }
 
 void trimTest(){


### PR DESCRIPTION
## JOINコマンドの実装


### 構成
```
executeAction
  └─ expandChannelsAndKeys   # チャンネル・キーをリスト化
  └─ joinOneChannel (×チャンネル数)
        ├─ isChannelNameValid  # チャンネル名の検証
        ├─ isJoinBlocked       # 参加制限チェック
        ├─ addClientToChannel  # メンバー追加
        └─ sendJoinReplies     # レスポンス送信
```
### 各ステップの概要
入力例 ->`JOIN #general,#secret key1,key2`

**1. パース**
`#general,#secret key1,key2` をカンマで分割し、チャンネルとキーを1対1で対応させる。

**2. チャンネル名検証**
先頭が `#`・2文字以上・スペース/カンマ/`\0` を含まないことを確認。違反なら 403。

**3. 参加制限チェック（既存チャンネルのみ）**

| 条件 | エラー |
|---|---|
| すでにメンバー | スキップ |
| invite-only かつ招待なし | 473 |
| キー不一致 | 475 |
| 上限超過 | 471 |

**4. メンバー追加**
チャンネルがなければ新規作成。作成者はオペレーター（`@`）になる。
invite-listから削除する。

**5. レスポンス送信**
- `JOIN` メッセージをチャンネル全員にブロードキャスト
- トピックあり → `332`、なし → `331`
- メンバー一覧を `353` + `366` で送信



## その他変更点
### Client.hpp / Client.cpp
- `prefix()` メソッドを追加（`nick!user@host` 形式の文字列を返す）

### User.cpp
- ウェルカムメッセージ生成を `client.prefix()` を使うよう短縮

### ServerLoop.cpp
- `waitForEvents` のバグ修正（`unrecoverableError` の判定が `poll()` 呼び出し前に評価されていた問題）

### commandTest.cpp
- JOINコマンドのテスト17ケースを追加
