### PR TITLE
TOPICコマンドの実装

### DIFF
--- a/srcs/Command/Topic.cpp
+++ b/srcs/Command/Topic.cpp
@@ -1,11 +1,47 @@
 #include "Topic.hpp"
 #include "Server.hpp"
 #include "Client.hpp"
+#include "Channel.hpp"
 
 void Topic::executeAction(Server& server, Client& client, int fd)
 {
-	(void)server;
-	(void)client;
-	(void)fd;
-	// TODO: implement TOPIC
+	if (params().empty() || params()[0][0] == ':')
+	{
+		server.sendError(client, fd, "461", "TOPIC :Not enough parameters");
+		return;
+	}
+	Channel* channel = server.findChannel(params()[0]);
+
+	if (channel == NULL)
+	{
+		server.sendError(client, fd, "403", params()[0] + " :No such channel");
+		return;
+	}
+	if (!channel->hasMember(&client))
+	{
+		server.sendError(client, fd, "442", params()[0] + " :You're not on that channel");
+		return;
+	}
+	if (params().size() == 1)
+	{
+		std::string topicReply;
+		if (!channel->topic().empty())
+			topicReply = ":ircserv 332 " + client.nickname() + " " + channel->name() + " :" + channel->topic() + "\r\n";
+		else
+			topicReply = ":ircserv 331 " + client.nickname() + " " + channel->name() + " :No topic is set\r\n";
+		client.appendToSendBuffer(topicReply);
+		return;
+	}
+	else
+	{
+		if (channel->isTopicRestricted() && !channel->isOperator(&client))
+		{
+			server.sendError(client, fd, "482", params()[0] + " :You're not channel operator");
+			return;
+		}
+		channel->setTopic(params()[1], client.nickname());
+		std::string topicChangeMsg = ":" + client.prefix() + " TOPIC " + channel->name() + " :" + channel->topic() + "\r\n";
+		channel->broadcast(topicChangeMsg);
+	}
+	return;
 }

--- a/srcs/Command/Topic.cpp
+++ b/srcs/Command/Topic.cpp
@@ -39,7 +39,7 @@ void Topic::executeAction(Server& server, Client& client, int fd)
 			server.sendError(client, fd, "482", params()[0] + " :You're not channel operator");
 			return;
 		}
-		channel->setTopic(params()[1], client.nickname());
+		channel->setTopic(params()[1].substr(1), client.nickname());
 		std::string topicChangeMsg = ":" + client.prefix() + " TOPIC " + channel->name() + " :" + channel->topic() + "\r\n";
 		channel->broadcast(topicChangeMsg);
 	}

--- a/srcs/commandTest.cpp
+++ b/srcs/commandTest.cpp
@@ -7,6 +7,7 @@
 #include "User.hpp"
 #include "Privmsg.hpp"
 #include "Join.hpp"
+#include "Topic.hpp"
 
 #include <iostream>
 
@@ -16,6 +17,7 @@ void NickTest();
 void RegisterTest();
 void PrivmsgTest();
 void JoinTest();
+void topicTest();
 
 static std::vector<std::string> makeParams()
 {
@@ -54,7 +56,8 @@ void commandTest()
 	// NickTest();
 	// RegisterTest();
 	// JoinTest();
-	PrivmsgTest();
+	// PrivmsgTest();
+	topicTest();
 }
 
 void PassTest(){
@@ -501,6 +504,53 @@ void JoinTest()
 	}
 
 	delete join;
+}
+
+void topicTest()
+{
+	std::cout << "<<Topic test>>" << std::endl;
+	Config config("6667", "password");
+	Server server(config);
+	Client* alice = makeRegisteredClient(server, 100, "alice");
+	Client* bob = makeRegisteredClient(server, 101, "bob");
+
+	Channel* ch = server.getOrCreateChannel("#general");
+	ch->addMember(alice);
+	ch->addMember(bob);
+
+	ACommand* topic = new Topic();
+
+	// パラメータなし → 461 Not enough parameters
+	{
+		std::cout << "-- no params --" << std::endl;
+		topic->execute(server, *alice, 100, makeParams());
+		printAndFlush(alice, "461 expected");
+	}
+
+	// チャンネル名のみ → トピック表示（トピックなし）
+	{
+		std::cout << "-- channel name only (no topic) --" << std::endl;
+		topic->execute(server, *alice, 100, makeParams("#general"));
+		printAndFlush(alice, "331 expected");
+	}
+
+	// チャンネル名のみ → トピック表示（トピックあり）
+	{
+		std::cout << "-- channel name only (with topic) --" << std::endl;
+		ch->setTopic("hello world", "alice");
+		topic->execute(server, *alice, 100, makeParams("#general"));
+		printAndFlush(alice, "332 expected");
+	}
+
+	// チャンネル名 + 新しいトピック → トピック変更
+	{
+		std::cout << "-- channel name + new topic --" << std::endl;
+		topic->execute(server, *alice, 100, makeParams("#general", "new topic"));
+		printAndFlush(alice, "topic changed expected");
+		printAndFlush(bob, "topic changed expected");
+	}
+
+	delete topic;
 }
 
 void trimTest(){

--- a/srcs/commandTest.cpp
+++ b/srcs/commandTest.cpp
@@ -54,7 +54,7 @@ void commandTest()
 	// trimTest();
 	// PassTest();
 	// NickTest();
-	// RegisterTest();
+	RegisterTest();
 	// JoinTest();
 	// PrivmsgTest();
 	topicTest();
@@ -240,11 +240,11 @@ void PrivmsgTest()
 		std::cout << "-- normal channel message --" << std::endl;
 		Channel* ch = server.getOrCreateChannel("#general");
 		ch->addMember(alice);
-		privmsg->execute(server, *alice, 100, makeParams("#general", "Hello everyone!"));
+		privmsg->execute(server, *alice, 100, makeParams("#general", ":Hello everyone!"));
 		printAndFlush(bob, "[channel] Hello everyone! expected");
 
 		// ユーザ宛 → 正常送信
-		privmsg->execute(server, *alice, 100, makeParams("bob", "Hello Bob!"));
+		privmsg->execute(server, *alice, 100, makeParams("bob", ":Hello Bob!"));
 		printAndFlush(bob, "[private] Hello Bob! expected");
 	}
 }
@@ -545,9 +545,9 @@ void topicTest()
 	// チャンネル名 + 新しいトピック → トピック変更
 	{
 		std::cout << "-- channel name + new topic --" << std::endl;
-		topic->execute(server, *alice, 100, makeParams("#general", "new topic"));
-		printAndFlush(alice, "topic changed expected");
-		printAndFlush(bob, "topic changed expected");
+		topic->execute(server, *alice, 100, makeParams("#general", ":new topic"));
+		printAndFlush(alice, "topic changed expected (alice)");
+		printAndFlush(bob, "topic changed expected (bob)");
 	}
 
 	delete topic;


### PR DESCRIPTION
## TOPICコマンドの実装

### 基本構文
```
TOPIC <channel> [:<topic>]
```
引数がチャンネル名だけのときは，該当チャンネルのTOPICを返信する．
トピックが存在する時は，332とトピックを返し．トピックが空のときは，331を返す．
TOPICが引数に含まれているときは，新しいTOPICとして設定する．

### エラーケース

**1. パラメータの不足**
```
TOPIC　←引数なし
TOPIC :new topic　←channelが不足
```
461エラー

**2. チャンネルのチェック**
チャンネルが存在しない→403エラー
チャンネルにいない→442エラー

**3. チャンネルの権限**
チャンネルに権限がないとき，かつ，オペレーターではないとき→482エラー

## その他変更点
### commandTest.cpp
- TOPICコマンドのテストケースを追加
