### PR TITLE
CAPコマンドの実装

### DIFF
--- a/includes/command/Cap.hpp
+++ b/includes/command/Cap.hpp
@@ -1,0 +1,12 @@
+#ifndef CAP_HPP
+#define CAP_HPP
+
+#include "ACommand.hpp"
+
+class Cap : public ACommand
+{
+	public:
+		void executeAction(Server& server, Client& client, int fd);
+};
+
+#endif

--- a/includes/command/Commands.hpp
+++ b/includes/command/Commands.hpp
@@ -14,5 +14,6 @@
 #include "Pong.hpp"
 #include "Quit.hpp"
 #include "Part.hpp"
+#include "Cap.hpp"
 
 #endif

--- a/srcs/Command/Cap.cpp
+++ b/srcs/Command/Cap.cpp
@@ -1,0 +1,16 @@
+#include "Cap.hpp"
+#include "Server.hpp"
+#include "Client.hpp"
+
+void Cap::executeAction(Server& server, Client& client, int fd)
+{
+	if (params().empty())
+		return;
+
+	const std::string& subcommand = params()[0];
+	if (subcommand == "LS")
+	{
+		client.appendToSendBuffer("CAP * LS :\r\n");
+		server.setPollout(fd, true);
+	}
+}

--- a/srcs/Command/Nick.cpp
+++ b/srcs/Command/Nick.cpp
@@ -22,8 +22,8 @@ void Nick::executeAction(Server& server, Client& client, int fd)
 	std::string old_nick = client.nickname();
 	client.setNickname(params()[0]);
 	client.appendToSendBuffer(":" + old_nick + " NICK " + client.nickname() + "\r\n");
+	server.setPollout(fd, true);
 	client.tryRegister();
-	return;
 }
 
 static bool isNicknameSymbol(char c);

--- a/srcs/Command/User.cpp
+++ b/srcs/Command/User.cpp
@@ -2,7 +2,7 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-static void sendWelcomeMessage(Client& client);
+static void sendWelcomeMessage(Server& server, Client& client, int fd);
 
 void User::executeAction(Server& server, Client& client, int fd)
 {
@@ -19,18 +19,12 @@ void User::executeAction(Server& server, Client& client, int fd)
 	client.setUsername(params()[0]);
 	client.setRealname(params()[3]);
 	if (client.tryRegister())
-	{
-		sendWelcomeMessage(client);
-	}
-	// else
-	// {	
-	// 	server.sendError(client, fd, "451", ":You have not registered");
-	// }
-	return;
+		sendWelcomeMessage(server, client, fd);
 }
 
-static void sendWelcomeMessage(Client& client)
+static void sendWelcomeMessage(Server& server, Client& client, int fd)
 {
-	std::string welcome_msg = client.nickname() + " :Welcome to the Internet Relay Network " + client.prefix() + "\r\n";
-	client.appendToSendBuffer(welcome_msg);
+	std::string msg = ":ircserv 001 " + client.nickname() + " :Welcome to the Internet Relay Network " + client.prefix() + "\r\n";
+	client.appendToSendBuffer(msg);
+	server.setPollout(fd, true);
 }

--- a/srcs/Server/ServerCommand.cpp
+++ b/srcs/Server/ServerCommand.cpp
@@ -13,6 +13,7 @@ static void skipSpaces(const std::string& line, std::string::size_type& pos);
 
 void Server::initCommandMap()
 {
+	_cmd_map["CAP"]     = new Cap();
 	_cmd_map["PASS"]    = new Pass();
 	_cmd_map["NICK"]    = new Nick();
 	_cmd_map["USER"]    = new User();
@@ -50,8 +51,8 @@ ACommand* Server::findInCmdMap(const std::string& command) const
 
 static bool isAllowedBeforeRegistration(const std::string& command)
 {
-	return command == "PASS" || command == "NICK"
-		|| command == "USER" || command == "QUIT";
+	return command == "CAP"  || command == "PASS"
+		|| command == "NICK" || command == "USER" || command == "QUIT";
 }
 
 void Server::deleteCommandMap()


### PR DESCRIPTION
## CAPコマンドの実装

| ファイル | 内容 |
|---|---|
| `includes/command/Cap.hpp` | `Cap` クラスの定義 |
| `srcs/Command/Cap.cpp` | `CAP LS` に空リストで応答し `setPollout` で即時送信 |
| `includes/command/Commands.hpp` | `Cap.hpp` を include 追加 |
| `srcs/Server/ServerCommand.cpp` | `CAP` をコマンドマップに登録、登録前許可リストに追加 |

### 背景

Irssiなどのモダンなクライアントは接続時に必ず `CAP LS` を送信する。
サーバーが応答しないと切断されるため `CAP` コマンドを実装した。


## その他変更点
・`appendToSendBuffer` 後に `setPollout` を呼ばないと送信バッファが flush されないバグを修正
・Userコマンドのwelcomeメッセージを変更


| ファイル | 内容 |
|---|---|
| `srcs/Command/Nick.cpp` | NICK応答後に `setPollout(fd, true)` を追加 |
| `srcs/Command/User.cpp` | welcomeメッセージを `:ircserv 001` numeric 付きに修正、`setPollout(fd, true)` を追加 |



