### PR TITLE
クライアントが切断された際に、参加しているチャンネルからメンバーを削除する処理を追加

### DIFF
--- a/srcs/Server/ServerClient.cpp
+++ b/srcs/Server/ServerClient.cpp
@@ -1,5 +1,6 @@
 #include "Server.hpp"
 #include "Client.hpp"
+#include "Channel.hpp"
 
 #include <iostream>
 #include <unistd.h>
@@ -30,11 +31,23 @@ void Server::removeClient(int fd)
 	if (it == _clients.end())
 		return;
 
-	std::cout << "Client disconnected: " << it->second->hostname()
+	Client* client = it->second;
+	std::cout << "Client disconnected: " << client->hostname()
 			  << " (fd " << fd << ")" << std::endl;
 
+	const std::set<std::string> channels = client->joinedChannels();
+	for (std::set<std::string>::const_iterator ch = channels.begin(); ch != channels.end(); ++ch)
+	{
+		Channel* channel = findChannel(*ch);
+		if (channel)
+		{
+			channel->removeMember(client);
+			deleteChannelIfEmpty(*ch);
+		}
+	}
+
 	close(fd);
-	delete it->second;
+	delete client;
 	_clients.erase(it);
 	unregisterPfd(fd);
 }


### PR DESCRIPTION
## SEGVの対応

クライアント切断時に、参加していたチャンネルのメンバーリストから
クライアントを退出させる処理を追加しました

### 変更 1: ローカル変数 client の導入

// 変更前
```
std::cout << "Client disconnected: " << it->second->hostname() ...
delete it->second;
```

// 変更後
```
Client* client = it->second;
std::cout << "Client disconnected: " << client->hostname() ...
delete client;
```
it->second を client 変数に取り出しています。後述の処理でも使うため、可読性と安全性のための整理です。

### 変更 2: 切断時にチャンネルからメンバーを削除する処理を追加

```
const std::set<std::string> channels = client->joinedChannels();
for (...) {
    Channel* channel = findChannel(*ch);
    if (channel) {
        channel->removeMember(client);
        deleteChannelIfEmpty(*ch);
    }
}
```
クライアントが切断された際に、参加していた全チャンネルから自動的に退出させる処理です。これがないと、delete client 後もチャンネルに無効なポインタが残り、dangling pointer によるクラッシュが発生します。