### PR TITLE
User - ユーザー名の検証機能を追加し、ユーザーコマンドのエラーハンドリングを強化

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -28,6 +28,7 @@ class Server
 		void	addToDisconnectList(int fd);
 		void	setPollout(int fd, bool enable);
 		void	sendError(Client& client, int fd, const std::string& code, const std::string& body);
+		void	sendWelcomeMessage(Client& client, int fd);
 
 		Channel*	findChannel(const std::string& name) const;
 		Channel*	getOrCreateChannel(const std::string& name);

--- a/includes/command/User.hpp
+++ b/includes/command/User.hpp
@@ -7,6 +7,8 @@ class User : public ACommand
 {
 	public:
 		void executeAction(Server& server, Client& client, int fd);
+	private:
+		bool isUsernameValid(const std::string& user);
 };
 
 #endif

--- a/srcs/Command/Nick.cpp
+++ b/srcs/Command/Nick.cpp
@@ -24,14 +24,7 @@ void Nick::executeAction(Server& server, Client& client, int fd)
 	client.appendToSendBuffer(":" + old_nick + " NICK " + client.nickname() + "\r\n");
 	server.setPollout(fd, true);
 	if (client.tryRegister())
-	{
-		const std::string& nick = client.nickname();
-		client.appendToSendBuffer(":ircserv 001 " + nick + " :Welcome to the Internet Relay Network " + client.prefix() + "\r\n");
-		client.appendToSendBuffer(":ircserv 002 " + nick + " :Your host is ircserv, running version 1.0\r\n");
-		client.appendToSendBuffer(":ircserv 003 " + nick + " :This server was created sometime\r\n");
-		client.appendToSendBuffer(":ircserv 004 " + nick + " ircserv 1.0 o itkol\r\n");
-		client.appendToSendBuffer(":ircserv 422 " + nick + " :MOTD File is missing\r\n");
-	}
+		server.sendWelcomeMessage(client, fd);
 }
 
 static bool isNicknameSymbol(char c);

--- a/srcs/Command/Nick.cpp
+++ b/srcs/Command/Nick.cpp
@@ -23,7 +23,15 @@ void Nick::executeAction(Server& server, Client& client, int fd)
 	client.setNickname(params()[0]);
 	client.appendToSendBuffer(":" + old_nick + " NICK " + client.nickname() + "\r\n");
 	server.setPollout(fd, true);
-	client.tryRegister();
+	if (client.tryRegister())
+	{
+		const std::string& nick = client.nickname();
+		client.appendToSendBuffer(":ircserv 001 " + nick + " :Welcome to the Internet Relay Network " + client.prefix() + "\r\n");
+		client.appendToSendBuffer(":ircserv 002 " + nick + " :Your host is ircserv, running version 1.0\r\n");
+		client.appendToSendBuffer(":ircserv 003 " + nick + " :This server was created sometime\r\n");
+		client.appendToSendBuffer(":ircserv 004 " + nick + " ircserv 1.0 o itkol\r\n");
+		client.appendToSendBuffer(":ircserv 422 " + nick + " :MOTD File is missing\r\n");
+	}
 }
 
 static bool isNicknameSymbol(char c);

--- a/srcs/Command/User.cpp
+++ b/srcs/Command/User.cpp
@@ -11,9 +11,14 @@ void User::executeAction(Server& server, Client& client, int fd)
 		server.sendError(client, fd, "461", "USER :Not enough parameters");
 		return;
 	}
-	if (client.tryRegister())
+	if (client.isRegistered())
 	{
 		server.sendError(client, fd, "462", ":You may not reregister");
+		return;
+	}
+	if (!isUsernameValid(params()[0]))
+	{
+		server.sendError(client, fd, "468", ":Your username is not valid");
 		return;
 	}
 	client.setUsername(params()[0]);
@@ -22,9 +27,26 @@ void User::executeAction(Server& server, Client& client, int fd)
 		sendWelcomeMessage(server, client, fd);
 }
 
+bool User::isUsernameValid(const std::string& user)
+{
+	if (user.empty())
+		return false;
+	for (size_t i = 0; i < user.size(); i++)
+	{
+		char c = user[i];
+		if (c == '\0' || c == '\r' || c == '\n' || c == ' ' || c == '@')
+			return false;
+	}
+	return true;
+}
+
 static void sendWelcomeMessage(Server& server, Client& client, int fd)
 {
-	std::string msg = ":ircserv 001 " + client.nickname() + " :Welcome to the Internet Relay Network " + client.prefix() + "\r\n";
-	client.appendToSendBuffer(msg);
+	const std::string& nick = client.nickname();
+	client.appendToSendBuffer(":ircserv 001 " + nick + " :Welcome to the Internet Relay Network " + client.prefix() + "\r\n");
+	client.appendToSendBuffer(":ircserv 002 " + nick + " :Your host is ircserv, running version 1.0\r\n");
+	client.appendToSendBuffer(":ircserv 003 " + nick + " :This server was created sometime\r\n");
+	client.appendToSendBuffer(":ircserv 004 " + nick + " ircserv 1.0 o itkol\r\n");
+	client.appendToSendBuffer(":ircserv 422 " + nick + " :MOTD File is missing\r\n");
 	server.setPollout(fd, true);
 }

--- a/srcs/Command/User.cpp
+++ b/srcs/Command/User.cpp
@@ -2,8 +2,6 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-static void sendWelcomeMessage(Server& server, Client& client, int fd);
-
 void User::executeAction(Server& server, Client& client, int fd)
 {
 	if (params().size() < 4)
@@ -24,7 +22,7 @@ void User::executeAction(Server& server, Client& client, int fd)
 	client.setUsername(params()[0]);
 	client.setRealname(params()[3]);
 	if (client.tryRegister())
-		sendWelcomeMessage(server, client, fd);
+		server.sendWelcomeMessage(client, fd);
 }
 
 bool User::isUsernameValid(const std::string& user)
@@ -38,15 +36,4 @@ bool User::isUsernameValid(const std::string& user)
 			return false;
 	}
 	return true;
-}
-
-static void sendWelcomeMessage(Server& server, Client& client, int fd)
-{
-	const std::string& nick = client.nickname();
-	client.appendToSendBuffer(":ircserv 001 " + nick + " :Welcome to the Internet Relay Network " + client.prefix() + "\r\n");
-	client.appendToSendBuffer(":ircserv 002 " + nick + " :Your host is ircserv, running version 1.0\r\n");
-	client.appendToSendBuffer(":ircserv 003 " + nick + " :This server was created sometime\r\n");
-	client.appendToSendBuffer(":ircserv 004 " + nick + " ircserv 1.0 o itkol\r\n");
-	client.appendToSendBuffer(":ircserv 422 " + nick + " :MOTD File is missing\r\n");
-	server.setPollout(fd, true);
 }

--- a/srcs/Server/ServerOut.cpp
+++ b/srcs/Server/ServerOut.cpp
@@ -28,6 +28,17 @@ void Server::handleClientWrite(int fd)
 		setPollout(fd, false);
 }
 
+void Server::sendWelcomeMessage(Client& client, int fd)
+{
+	const std::string& nick = client.nickname();
+	client.appendToSendBuffer(":ircserv 001 " + nick + " :Welcome to the Internet Relay Network " + client.prefix() + "\r\n");
+	client.appendToSendBuffer(":ircserv 002 " + nick + " :Your host is ircserv, running version 1.0\r\n");
+	client.appendToSendBuffer(":ircserv 003 " + nick + " :This server was created sometime\r\n");
+	client.appendToSendBuffer(":ircserv 004 " + nick + " ircserv 1.0 o itkol\r\n");
+	client.appendToSendBuffer(":ircserv 422 " + nick + " :MOTD File is missing\r\n");
+	setPollout(fd, true);
+}
+
 void Server::sendError(Client& client, int fd, const std::string& code, const std::string& body)
 {
 	std::string nick = client.nickname();

--- a/srcs/commandTest.cpp
+++ b/srcs/commandTest.cpp
@@ -15,6 +15,7 @@ void PassTest();
 void trimTest();
 void NickTest();
 void RegisterTest();
+void UserTest();
 void PrivmsgTest();
 void JoinTest();
 void topicTest();
@@ -54,10 +55,11 @@ void commandTest()
 	// trimTest();
 	// PassTest();
 	// NickTest();
-	RegisterTest();
+	// RegisterTest();
+	UserTest();
 	// JoinTest();
 	// PrivmsgTest();
-	topicTest();
+	// topicTest();
 }
 
 void PassTest(){
@@ -194,6 +196,138 @@ static void printAndFlush(Client* client, const std::string& label)
 {
 	std::cout << "[" << label << "] " << client->sendBuffer();
 	client->removeSentData(client->sendBuffer().length());
+}
+
+void UserTest()
+{
+	std::cout << "<<User test>>" << std::endl;
+	Config config("6667", "password");
+
+	// 461: パラメータ不足
+	{
+		std::cout << "-- not enough params (461 expected) --" << std::endl;
+		Server server(config);
+		Client* client = new Client(0, "localhost");
+		ACommand* user = new User();
+		user->execute(server, *client, 0, makeParams("user1", "0"));
+		std::cout << client->sendBuffer();
+		client->removeSentData(client->sendBuffer().length());
+		delete user;
+	}
+
+	// 462: 登録済みに再送 → ERR_ALREADYREGISTERED
+	{
+		std::cout << "-- already registered (462 expected) --" << std::endl;
+		Server server(config);
+		Client* client = makeRegisteredClient(server, 0, "alice");
+		ACommand* user = new User();
+		user->execute(server, *client, 0, makeParams("other", "0", "*", ":Other Name"));
+		std::cout << client->sendBuffer();
+		client->removeSentData(client->sendBuffer().length());
+		delete user;
+	}
+
+	// 468: 無効なusername（@を含む）
+	{
+		std::cout << "-- invalid username with @ (468 expected) --" << std::endl;
+		Server server(config);
+		Client* client = new Client(0, "localhost");
+		ACommand* user = new User();
+		user->execute(server, *client, 0, makeParams("bad@name", "0", "*", ":Real"));
+		std::cout << client->sendBuffer();
+		client->removeSentData(client->sendBuffer().length());
+		delete user;
+	}
+
+	// 468: 無効なusername（スペースを含む）
+	{
+		std::cout << "-- invalid username with space (468 expected) --" << std::endl;
+		Server server(config);
+		Client* client = new Client(0, "localhost");
+		ACommand* user = new User();
+		user->execute(server, *client, 0, makeParams("bad name", "0", "*", ":Real"));
+		std::cout << client->sendBuffer();
+		client->removeSentData(client->sendBuffer().length());
+		delete user;
+	}
+
+	// PASS→USER→NICK の順で welcome が届く
+	{
+		std::cout << "-- PASS->USER->NICK order (001 expected on NICK) --" << std::endl;
+		Server server(config);
+		Client* client = new Client(0, "localhost");
+		server.addClient(0, client);
+
+		ACommand* pass = new Pass();
+		pass->execute(server, *client, 0, makeParams("password"));
+		client->removeSentData(client->sendBuffer().length());
+		delete pass;
+
+		ACommand* user = new User();
+		user->execute(server, *client, 0, makeParams("tomo", "0", "*", ":Tomo Ka"));
+		std::string after_user = client->sendBuffer();
+		client->removeSentData(after_user.length());
+		if (after_user.empty())
+			std::cout << "[USER before NICK] OK: no welcome yet" << std::endl;
+		else
+			std::cout << "[USER before NICK] NG: unexpected reply: " << after_user;
+		delete user;
+
+		ACommand* nick = new Nick();
+		nick->execute(server, *client, 0, makeParams("tochi"));
+		std::string after_nick = client->sendBuffer();
+		client->removeSentData(after_nick.length());
+		if (after_nick.find("001") != std::string::npos)
+			std::cout << "[NICK completes reg] OK: 001 received" << std::endl;
+		else
+			std::cout << "[NICK completes reg] NG: 001 not received: " << after_nick;
+		delete nick;
+	}
+
+	// PASSなしで NICK+USER → 登録されない（welcome なし）
+	{
+		std::cout << "-- no PASS, NICK+USER -> no welcome --" << std::endl;
+		Server server(config);
+		Client* client = new Client(0, "localhost");
+		server.addClient(0, client);
+
+		ACommand* nick = new Nick();
+		nick->execute(server, *client, 0, makeParams("tochi"));
+		client->removeSentData(client->sendBuffer().length());
+		delete nick;
+
+		ACommand* user = new User();
+		user->execute(server, *client, 0, makeParams("tomo", "0", "*", ":Tomo Ka"));
+		std::string buf = client->sendBuffer();
+		client->removeSentData(buf.length());
+		if (buf.find("001") == std::string::npos)
+			std::cout << "[no PASS] OK: no welcome sent" << std::endl;
+		else
+			std::cout << "[no PASS] NG: got unexpected 001" << std::endl;
+		delete user;
+	}
+
+	// PASS+NICK のみ（USER未送信）→ 登録されない
+	{
+		std::cout << "-- PASS+NICK only, no USER -> not registered --" << std::endl;
+		Server server(config);
+		Client* client = new Client(0, "localhost");
+		server.addClient(0, client);
+
+		ACommand* pass = new Pass();
+		pass->execute(server, *client, 0, makeParams("password"));
+		client->removeSentData(client->sendBuffer().length());
+		delete pass;
+
+		ACommand* nick = new Nick();
+		nick->execute(server, *client, 0, makeParams("tochi"));
+		client->removeSentData(client->sendBuffer().length());
+		if (!client->isRegistered())
+			std::cout << "[no USER] OK: not registered" << std::endl;
+		else
+			std::cout << "[no USER] NG: registered without USER" << std::endl;
+		delete nick;
+	}
 }
 
 void PrivmsgTest()


### PR DESCRIPTION
## USERコマンド変更

### 修正
登録済みの判定を `tryRegister() → isRegistered() `に変更

### 処理の追加

- エラー468 追加:

   username に `\0` /` \r` / `\n` / `スペース `/ `@ `が含まれる場合にエラーを返す`isUsernameValid() `を追加

### テスト追加

- 461 パラメータ不足
- 462 登録済みへの再送
- 468 無効な username（@ 含む / スペース含む）
- PASS→USER→NICK 順での正常登録
- PASS なしでの登録失敗
- USER 未送信での登録失敗

## その他変更点
 ### Welcomeメッセージ拡充 
  001 のみ → 001〜004 + 422 (ERR_NOMOTD) に対応
- `serverOut.cppにsendWelcomeMessage()`を実装
- Nick/User で上記関数を呼び出すように変更