### PR TITLE
実装: QUITコマンドの処理を追加

### DIFF
--- a/srcs/Command/Privmsg.cpp
+++ b/srcs/Command/Privmsg.cpp
@@ -17,17 +17,21 @@ void Privmsg::executeAction(Server& server, Client& client, int fd)
 	std::vector<std::string> receivers;
 	receivers = splitByComma(params()[0]);
 
+	std::string message = params()[1];
+	if (!message.empty() && message[0] == ':')
+		message = message.substr(1);
+
 	for (std::vector<std::string>::iterator it = receivers.begin(); it != receivers.end(); ++it)
 	{
 		if (it->at(0) == '#')
 		{
 			std::string channel_name = *it;
-			sendForChannel(server, client, fd, channel_name, params()[1]);
+			sendForChannel(server, client, fd, channel_name, message);
 		}
 		else
 		{
-			sendForTarget(server, client, fd, *it, params()[1]);
-		}	
+			sendForTarget(server, client, fd, *it, message);
+		}
 	}
 	return;
 }

--- a/srcs/Command/Quit.cpp
+++ b/srcs/Command/Quit.cpp
@@ -1,11 +1,23 @@
 #include "Quit.hpp"
 #include "Server.hpp"
 #include "Client.hpp"
+#include "Channel.hpp"
 
 void Quit::executeAction(Server& server, Client& client, int fd)
 {
-	(void)server;
-	(void)client;
-	(void)fd;
-	// TODO: implement QUIT
+	std::string reason = "";
+	if (!params().empty())
+		reason = params()[0];
+
+	std::string quitMsg = ":" + client.prefix() + " QUIT :" + reason + "\r\n";
+
+	const std::set<std::string> channels = client.joinedChannels();
+	for (std::set<std::string>::const_iterator it = channels.begin(); it != channels.end(); ++it)
+	{
+		Channel* channel = server.findChannel(*it);
+		if (channel)
+			channel->broadcast(quitMsg, &client);
+	}
+
+	server.addToDisconnectList(fd);
 }

--- a/srcs/Command/Quit.cpp
+++ b/srcs/Command/Quit.cpp
@@ -7,7 +7,11 @@ void Quit::executeAction(Server& server, Client& client, int fd)
 {
 	std::string reason = "";
 	if (!params().empty())
+	{
 		reason = params()[0];
+		if (!reason.empty() && reason[0] == ':')
+			reason = reason.substr(1);
+	}
 
 	std::string quitMsg = ":" + client.prefix() + " QUIT :" + reason + "\r\n";
 

--- a/srcs/Command/User.cpp
+++ b/srcs/Command/User.cpp
@@ -20,7 +20,10 @@ void User::executeAction(Server& server, Client& client, int fd)
 		return;
 	}
 	client.setUsername(params()[0]);
-	client.setRealname(params()[3]);
+	std::string realname = params()[3];
+	if (!realname.empty() && realname[0] == ':')
+		realname = realname.substr(1);
+	client.setRealname(realname);
 	if (client.tryRegister())
 		server.sendWelcomeMessage(client, fd);
 }


### PR DESCRIPTION
## QUITコマンド

### 入力
`QUIT : <reason>`

### 基本仕様
clientからserverに切断のリクエストを送って離脱する。
reasonは省略可能。
clientが所属していた全チャンネルに離脱のメッセージを送る。

## その他変更点

setParamsの仕様変更に伴い、以下のコマンドで`":"`の扱いを変更

・Privmsg
・User
