### PR TITLE
KICKコマンドの実装

### DIFF
--- a/srcs/Command/Kick.cpp
+++ b/srcs/Command/Kick.cpp
@@ -40,11 +40,11 @@ void Kick::executeAction(Server& server, Client& client, int fd)
 		server.sendError(client, fd, "441", params()[1] + " " + params()[0] + " :They aren't on that channel");
 		return;
 	}
-	channel->removeMember(targetClient);
 	std::string kickMsg;
 	if (params().size() == 2)
 		kickMsg = ":" + client.prefix() + " KICK " + channel->name() + " " + targetClient->nickname();
 	else
 		kickMsg = ":" + client.prefix() + " KICK " + channel->name() + " " + targetClient->nickname() + " :" + params()[2];
 	server.broadcastToChannel(channel, kickMsg);
+	channel->removeMember(targetClient);
 }

--- a/srcs/Command/Kick.cpp
+++ b/srcs/Command/Kick.cpp
@@ -47,4 +47,5 @@ void Kick::executeAction(Server& server, Client& client, int fd)
 		kickMsg = ":" + client.prefix() + " KICK " + channel->name() + " " + targetClient->nickname() + " :" + params()[2];
 	server.broadcastToChannel(channel, kickMsg);
 	channel->removeMember(targetClient);
+	server.deleteChannelIfEmpty(channel->name());
 }

--- a/srcs/Command/Kick.cpp
+++ b/srcs/Command/Kick.cpp
@@ -1,11 +1,50 @@
 #include "Kick.hpp"
 #include "Server.hpp"
 #include "Client.hpp"
+#include "Channel.hpp"
 
 void Kick::executeAction(Server& server, Client& client, int fd)
 {
 	(void)server;
 	(void)client;
 	(void)fd;
-	// TODO: implement KICK
+	if (params().size() < 2)
+	{
+		server.sendError(client, fd, "461", "KICK :Not enough parameters");
+		return;
+	}
+	Channel* channel = server.findChannel(params()[0]);
+	if (channel == NULL)
+	{
+		server.sendError(client, fd, "403", params()[0] + " :No such channel");
+		return;	
+	}
+	Client* targetClient = server.findClientByNick(params()[1]);
+	if (targetClient == NULL)
+	{
+		server.sendError(client, fd, "401", params()[1] + " :No such nick/channel");
+		return;	
+	}
+	if (!channel->hasMember(&client))
+	{
+		server.sendError(client, fd, "442", params()[0] + " :You're not on that channel");
+		return;	
+	}
+	if (!channel->isOperator(&client))
+	{
+		server.sendError(client, fd, "482", params()[0] + " :You're not channel operator");
+		return;	
+	}
+	if (!channel->hasMember(targetClient))
+	{		
+		server.sendError(client, fd, "441", params()[1] + " " + params()[0] + " :They aren't on that channel");
+		return;
+	}
+	channel->removeMember(targetClient);
+	std::string kickMsg;
+	if (params().size() == 2)
+		kickMsg = ":" + client.prefix() + " KICK " + channel->name() + " " + targetClient->nickname();
+	else
+		kickMsg = ":" + client.prefix() + " KICK " + channel->name() + " " + targetClient->nickname() + " :" + params()[2];
+	server.broadcastToChannel(channel, kickMsg);
 }

--- a/srcs/commandTest.cpp
+++ b/srcs/commandTest.cpp
@@ -8,6 +8,7 @@
 #include "Privmsg.hpp"
 #include "Join.hpp"
 #include "Topic.hpp"
+#include "Kick.hpp"
 
 #include <iostream>
 
@@ -19,6 +20,7 @@ void UserTest();
 void PrivmsgTest();
 void JoinTest();
 void topicTest();
+void kickTest();
 
 static std::vector<std::string> makeParams()
 {
@@ -56,10 +58,11 @@ void commandTest()
 	// PassTest();
 	// NickTest();
 	// RegisterTest();
-	UserTest();
+	// UserTest();
 	// JoinTest();
 	// PrivmsgTest();
 	// topicTest();
+	kickTest();
 }
 
 void PassTest(){
@@ -685,6 +688,80 @@ void topicTest()
 	}
 
 	delete topic;
+}
+
+void kickTest()
+{
+	std::cout << "<<Kick test>>" << std::endl;
+	Config config("6667", "password");
+	Server server(config);
+	Client* alice = makeRegisteredClient(server, 100, "alice");
+	Client* bob = makeRegisteredClient(server, 101, "bob");
+
+	Channel* ch = server.getOrCreateChannel("#general");
+	ch->addMember(alice);
+	ch->setOperator(alice, true);
+	ch->addMember(bob);
+
+	ACommand* kick = new Kick();
+
+	// パラメータなし → 461 Not enough parameters
+	{
+		std::cout << "-- no params --" << std::endl;
+		kick->execute(server, *alice, 100, makeParams());
+		printAndFlush(alice, "461 expected");
+	}
+
+	// チャンネル名のみ → 461 Not enough parameters
+	{
+		std::cout << "-- channel name only --" << std::endl;
+		kick->execute(server, *alice, 100, makeParams("#general"));
+		printAndFlush(alice, "461 expected");
+	}
+
+	// 存在しないUser名 → 401 No such nick/channel
+	{
+		std::cout << "-- user not in channel --" << std::endl;
+		kick->execute(server, *alice, 100, makeParams("#general", "tomo"));
+		printAndFlush(alice, "401 expected");
+	}
+
+	// 存在しないチャンネル
+	{
+		std::cout << "-- no such channel --" << std::endl;
+		kick->execute(server, *alice, 100, makeParams("#normal", "tomo"));
+		printAndFlush(alice, "403 expected");
+	}
+
+	// 権限がない
+	{
+		std::cout << "-- no permission --" << std::endl;
+		kick->execute(server, *bob, 100, makeParams("#general", "alice"));
+		printAndFlush(bob, "482 expected");
+	}
+
+	// チャンネル名 + ユーザ名 → 正常キック
+	{
+		std::cout << "-- channel name + user name --" << std::endl;
+		kick->execute(server, *alice, 100, makeParams("#general", "bob"));
+		printAndFlush(alice, "kick successful expected (alice)");
+		printAndFlush(bob, "kick received expected (bob)");
+	}
+
+	// チャンネルに存在しない
+	{
+		std::cout << "-- no exitst user in channel --" << std::endl;
+		kick->execute(server, *alice, 100, makeParams("#general", "bob"));
+		printAndFlush(alice, "441 expected");
+	}
+
+	//自分自身もキックできる
+	{
+		std::cout << "-- kick self --" << std::endl;
+		kick->execute(server, *alice, 100, makeParams("#general", "alice"));
+		printAndFlush(alice, "kick self expected");
+	}
+	delete kick;
 }
 
 void trimTest(){


### PR DESCRIPTION
# 基本構文
```
KICK <channel> <user> [:<comment>]
```
基本的にオペレーターのみKICK可能
自分自身のこともKICK可能

# 動作
```
:nick!user@host KICK #general tochi :spam
```
nick = 実行者（キックした人）
tochi = 退出させられた人
:spam = 理由（省略可）
上記のメッセージがチャンネル内の全員（KICKされた人を含む）に送信される
メッセージの送信->ユーザのKICK

# エラー一覧
| 条件 | エラー |
| -- | -- |
|パラーメータの不足|461|
|ユーザーが存在しない|401|
|チャンネルが存在しない|403|
|チャンネルにいない|442|
|権限がない|482|
|対象のユーザーがチャンネルにいない|441|

