### PR TITLE
PARTコマンドの実装

### DIFF
--- a/srcs/Command/Part.cpp
+++ b/srcs/Command/Part.cpp
@@ -16,11 +16,16 @@ void Part::executeAction(Server& server, Client& client, int fd)
 		server.sendError(client, fd, "403", params()[0] + " :No such channel");
 		return;	
 	}
+	if (!channel->hasMember(&client))
+	{
+		server.sendError(client, fd, "442", params()[0] + " :You're not on that channel");
+		return;	
+	}
 	std::string partMsg;
-	if (params().size() == 2)
-		partMsg = ":" + client.prefix() + " PART " + channel->name();
+	if (params().size() == 1)
+		partMsg = ":" + client.prefix() + " PART " + channel->name() + "\r\n";
 	else
-		partMsg = ":" + client.prefix() + " PART " + channel->name() + " :" + params()[2];
+		partMsg = ":" + client.prefix() + " PART " + channel->name() + " " + params()[1]+ "\r\n";
 	server.broadcastToChannel(channel, partMsg);
 	channel->removeMember(&client);
 	server.deleteChannelIfEmpty(channel->name());

--- a/srcs/Command/Part.cpp
+++ b/srcs/Command/Part.cpp
@@ -1,11 +1,27 @@
 #include "Part.hpp"
 #include "Server.hpp"
 #include "Client.hpp"
+#include "Channel.hpp"
 
 void Part::executeAction(Server& server, Client& client, int fd)
 {
-	(void)server;
-	(void)client;
-	(void)fd;
-	// TODO: implement PART
+	if (params().empty() || params()[0][0] == ':')
+	{
+		server.sendError(client, fd, "461", "PART :Not enough parameters");
+		return;
+	}
+	Channel* channel = server.findChannel(params()[0]);
+	if (channel == NULL)
+	{
+		server.sendError(client, fd, "403", params()[0] + " :No such channel");
+		return;	
+	}
+	std::string partMsg;
+	if (params().size() == 2)
+		partMsg = ":" + client.prefix() + " PART " + channel->name();
+	else
+		partMsg = ":" + client.prefix() + " PART " + channel->name() + " :" + params()[2];
+	server.broadcastToChannel(channel, partMsg);
+	channel->removeMember(&client);
+	server.deleteChannelIfEmpty(channel->name());
 }

--- a/srcs/commandTest.cpp
+++ b/srcs/commandTest.cpp
@@ -9,6 +9,7 @@
 #include "Join.hpp"
 #include "Topic.hpp"
 #include "Kick.hpp"
+#include "Part.hpp"
 
 #include <iostream>
 
@@ -21,6 +22,7 @@ void PrivmsgTest();
 void JoinTest();
 void topicTest();
 void kickTest();
+void partTest();
 
 static std::vector<std::string> makeParams()
 {
@@ -62,7 +64,8 @@ void commandTest()
 	// JoinTest();
 	// PrivmsgTest();
 	// topicTest();
-	kickTest();
+	// kickTest();
+	partTest();
 }
 
 void PassTest(){
@@ -762,6 +765,66 @@ void kickTest()
 		printAndFlush(alice, "kick self expected");
 	}
 	delete kick;
+}
+
+void partTest()
+{
+	std::cout << "<<Part test>>" << std::endl;
+	Config config("6667", "password");
+	Server server(config);
+	Client* alice = makeRegisteredClient(server, 100, "alice");
+	Client* bob = makeRegisteredClient(server, 101, "bob");
+
+	Channel* ch = server.getOrCreateChannel("#general");
+	ch->addMember(alice);
+	ch->addMember(bob);
+
+	ACommand* part = new Part();
+
+	// パラメータなし → 461 Not enough parameters
+	{
+		std::cout << "-- no params --" << std::endl;
+		part->execute(server, *alice, 100, makeParams());
+		printAndFlush(alice, "461 expected");
+	}
+
+	// チャンネルなし → 461 Not enough parameters
+	{
+		std::cout << "-- no params --" << std::endl;
+		part->execute(server, *alice, 100, makeParams(":bye"));
+		printAndFlush(alice, "461 expected");
+	}
+
+	// 存在しないチャンネル → 403 No such channel
+	{
+		std::cout << "-- no such channel --" << std::endl;
+		part->execute(server, *alice, 100, makeParams("#normal"));
+		printAndFlush(alice, "403 expected");
+	}
+
+	// チャンネル名 → 正常PART
+	{
+		std::cout << "-- channel name --" << std::endl;
+		part->execute(server, *alice, 100, makeParams("#general"));
+		printAndFlush(alice, "part successful expected (alice)");
+		printAndFlush(bob, "part received expected (bob)");
+	}
+
+	// チャンネル名 → 正常PART
+	{
+		std::cout << "-- channel name --" << std::endl;
+		part->execute(server, *bob, 100, makeParams("#general", ":bye"));
+		printAndFlush(bob, "part received expected (bob)");
+	}
+
+	// チャンネルにいない　-> 442 Not on channel
+	{
+		std::cout << std::endl << "-- not on channel --" << std::endl;
+		part->execute(server, *alice, 100, makeParams("#general"));
+		printAndFlush(alice, "442 expected");
+	}
+
+	delete part;
 }
 
 void trimTest(){


### PR DESCRIPTION
# 基本構文
```
PART <channel> [:<message>]
```

# 動作
```
:nick!user@host PART #general : bye
```
#general =  チャンネル名
:bye = メッセージ（省略可）
上記のメッセージがチャンネル内の全員（自分を含む）に送信される
メッセージの送信->ユーザの削除

# エラー一覧
| 条件 | エラー |
| -- | -- |
|パラーメータの不足|461|
|チャンネルが存在しない|403|
|チャンネルにいない|442|

