### PR TITLE
Takawagu/fix/errno

### DIFF
--- a/errno_fix_test.sh
+++ b/errno_fix_test.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+PORT=6668
+PASS=pass
+SERVER=./ircserv
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+ok()   { echo -e "${GREEN}[PASS]${NC} $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+start_server() {
+	$SERVER $PORT $PASS > /tmp/irc_server.log 2>&1 &
+	SERVER_PID=$!
+	sleep 0.3
+	if ! kill -0 $SERVER_PID 2>/dev/null; then
+		echo -e "${RED}[ERROR]${NC} Server failed to start"
+		exit 1
+	fi
+	info "Server started (PID: $SERVER_PID)"
+}
+
+stop_server() {
+	kill -INT $SERVER_PID 2>/dev/null
+	wait $SERVER_PID 2>/dev/null
+}
+
+# printf 後に sleep して stdin を保持し、サーバーの応答を受け取る
+irc() {
+	local cmds="$1"
+	local hold="${2:-1}"
+	local outfile="$3"
+	{ printf "%b" "$cmds"; sleep "$hold"; } | timeout $((hold + 2)) nc 127.0.0.1 $PORT > "$outfile" 2>/dev/null
+}
+
+echo "=== errno fix tests ==="
+echo ""
+
+# -------------------------------------------------------
+# Test 1: recv path — サーバーが正しくデータを受信・処理できるか
+# -------------------------------------------------------
+info "Test 1: recv path - 正常登録フロー (001 Welcome)"
+start_server
+irc "PASS $PASS\r\nNICK alice\r\nUSER alice 0 * :Alice\r\n" 1 /tmp/irc_out.txt
+if grep -q "001" /tmp/irc_out.txt; then
+	ok "recv: Welcome (001) を受信"
+else
+	fail "recv: 001 が返らなかった"
+	cat /tmp/irc_out.txt
+fi
+stop_server
+
+# -------------------------------------------------------
+# Test 2: send path — サーバーが正しくデータを送信できるか
+# -------------------------------------------------------
+info "Test 2: send path - PRIVMSG が別クライアントに届く"
+start_server
+
+irc "PASS $PASS\r\nNICK bob\r\nUSER bob 0 * :Bob\r\nJOIN #test\r\n" 2 /tmp/irc_bob.txt &
+BOB_PID=$!
+sleep 0.5
+
+irc "PASS $PASS\r\nNICK carol\r\nUSER carol 0 * :Carol\r\nJOIN #test\r\nPRIVMSG #test :hello\r\n" 1 /tmp/irc_carol.txt
+sleep 0.5
+
+wait $BOB_PID 2>/dev/null
+if grep -q "hello" /tmp/irc_bob.txt; then
+	ok "send: bob が carol の PRIVMSG を受信"
+else
+	fail "send: PRIVMSG が届かなかった"
+fi
+stop_server
+
+# -------------------------------------------------------
+# Test 3: accept path — 複数クライアントの同時接続
+# -------------------------------------------------------
+info "Test 3: accept path - 3クライアント同時接続"
+start_server
+
+irc "PASS $PASS\r\nNICK u1\r\nUSER u1 0 * :U1\r\n" 1 /tmp/irc_u1.txt &
+P1=$!
+irc "PASS $PASS\r\nNICK u2\r\nUSER u2 0 * :U2\r\n" 1 /tmp/irc_u2.txt &
+P2=$!
+irc "PASS $PASS\r\nNICK u3\r\nUSER u3 0 * :U3\r\n" 1 /tmp/irc_u3.txt &
+P3=$!
+wait $P1 $P2 $P3
+
+ALL_OK=true
+for f in /tmp/irc_u1.txt /tmp/irc_u2.txt /tmp/irc_u3.txt; do
+	if ! grep -q "001" "$f"; then
+		ALL_OK=false
+	fi
+done
+
+if $ALL_OK; then
+	ok "accept: 3クライアント全員が 001 を受信"
+else
+	fail "accept: 一部クライアントの接続に失敗"
+fi
+stop_server
+
+# -------------------------------------------------------
+# Test 4: poll path — SIGINT でのグレースフルシャットダウン
+# -------------------------------------------------------
+info "Test 4: poll path - SIGINT グレースフルシャットダウン"
+start_server
+
+irc "PASS $PASS\r\nNICK stay\r\nUSER stay 0 * :Stay\r\nJOIN #ch\r\n" 5 /tmp/irc_stay.txt &
+NC_PID=$!
+sleep 0.5
+
+kill -INT $SERVER_PID
+wait $SERVER_PID 2>/dev/null
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -eq 0 ]; then
+	ok "poll: SIGINT 後に exit code 0 で正常終了"
+else
+	fail "poll: 終了コードが $EXIT_CODE (期待値 0)"
+fi
+wait $NC_PID 2>/dev/null
+
+# -------------------------------------------------------
+# Test 5: 再起動後も正常動作するか
+# -------------------------------------------------------
+info "Test 5: サーバー再起動後の動作"
+start_server
+irc "PASS $PASS\r\nNICK dave\r\nUSER dave 0 * :Dave\r\n" 1 /tmp/irc_dave.txt
+if grep -q "001" /tmp/irc_dave.txt; then
+	ok "再起動後も正常に接続・応答"
+else
+	fail "再起動後の接続に失敗"
+fi
+stop_server
+
+# -------------------------------------------------------
+echo ""
+echo "=== Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed ==="
+[ $FAIL_COUNT -eq 0 ] && exit 0 || exit 1

--- a/leak_test.sh
+++ b/leak_test.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+PORT=6667
+PASS=pass
+SERVER=./ircserv
+WAIT=0.3
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+run_test() {
+	local name="$1"
+	local cmds="$2"
+	echo -e "${YELLOW}[TEST]${NC} $name"
+	printf "%b" "$cmds" | timeout 2 nc -C 127.0.0.1 $PORT > /dev/null 2>&1
+	sleep $WAIT
+}
+
+# サーバー起動
+$SERVER $PORT $PASS &
+SERVER_PID=$!
+sleep 0.5
+
+if ! kill -0 $SERVER_PID 2>/dev/null; then
+	echo -e "${RED}[ERROR]${NC} Server failed to start"
+	exit 1
+fi
+echo -e "${GREEN}[INFO]${NC} Server started (PID: $SERVER_PID)"
+
+# テストケース実行
+run_test "登録前に切断" \
+	"\r\n"
+
+run_test "PASSのみ送って切断" \
+	"PASS $PASS\r\n"
+
+run_test "NICK まで送って切断" \
+	"PASS $PASS\r\nNICK test\r\n"
+
+run_test "正常登録後に切断" \
+	"PASS $PASS\r\nNICK test\r\nUSER test 0 * :Test User\r\n"
+
+run_test "チャンネル参加後に切断" \
+	"PASS $PASS\r\nNICK test\r\nUSER test 0 * :Test User\r\nJOIN #ch1\r\nJOIN #ch2\r\nJOIN #ch3\r\n"
+
+run_test "不完全なコマンドで切断" \
+	"PASS $PASS\r\nNICK test\r\nUSER test 0 * :Test User\r\nJOI\r\n"
+
+echo -e "${YELLOW}[TEST]${NC} 複数クライアント同時接続・切断"
+printf "PASS $PASS\r\nNICK user1\r\nUSER user1 0 * :User1\r\n" | timeout 2 nc -C 127.0.0.1 $PORT > /dev/null 2>&1 &
+PID1=$!
+printf "PASS $PASS\r\nNICK user2\r\nUSER user2 0 * :User2\r\n" | timeout 2 nc -C 127.0.0.1 $PORT > /dev/null 2>&1 &
+PID2=$!
+printf "PASS $PASS\r\nNICK user3\r\nUSER user3 0 * :User3\r\n" | timeout 2 nc -C 127.0.0.1 $PORT > /dev/null 2>&1 &
+PID3=$!
+wait $PID1 $PID2 $PID3
+sleep $WAIT
+
+echo -e "${YELLOW}[TEST]${NC} アクティブなクライアントがいる状態でサーバー停止前"
+printf "PASS $PASS\r\nNICK test\r\nUSER test 0 * :Test User\r\nJOIN #ch1\r\n" | timeout 5 nc -C 127.0.0.1 $PORT > /dev/null 2>&1 &
+LAST_NC_PID=$!
+sleep $WAIT
+
+# leaks チェック（サーバー起動中）
+echo ""
+echo -e "${GREEN}[INFO]${NC} Running leaks check on running server..."
+leaks $SERVER_PID 2>&1 | tail -20
+
+# サーバー停止
+kill -INT $SERVER_PID
+wait $SERVER_PID 2>/dev/null
+wait $LAST_NC_PID 2>/dev/null
+
+echo ""
+echo -e "${GREEN}[INFO]${NC} All tests completed."

--- a/srcs/Command/Kick.cpp
+++ b/srcs/Command/Kick.cpp
@@ -44,7 +44,12 @@ void Kick::executeAction(Server& server, Client& client, int fd)
 	if (params().size() == 2)
 		kickMsg = ":" + client.prefix() + " KICK " + channel->name() + " " + targetClient->nickname() + "\r\n";
 	else
-		kickMsg = ":" + client.prefix() + " KICK " + channel->name() + " " + targetClient->nickname() + " :" + params()[2] + "\r\n";
+	{
+		std::string reason = params()[2];
+		if (!reason.empty() && reason[0] == ':')
+			reason = reason.substr(1);
+		kickMsg = ":" + client.prefix() + " KICK " + channel->name() + " " + targetClient->nickname() + " :" + reason + "\r\n";
+	}
 	server.broadcastToChannel(channel, kickMsg);
 	channel->removeMember(targetClient);
 	server.deleteChannelIfEmpty(channel->name());

--- a/srcs/Server/ServerAccept.cpp
+++ b/srcs/Server/ServerAccept.cpp
@@ -1,8 +1,6 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-#include <cerrno>
-#include <cstring>
 #include <iostream>
 #include <arpa/inet.h>
 #include <fcntl.h>
@@ -38,15 +36,7 @@ int Server::acceptConnection(struct sockaddr_in& addr)
 
 bool Server::isAcceptSuccessful(int client_fd)
 {
-	bool unrecoverableError = (errno != EAGAIN && errno != EWOULDBLOCK);
-
-	if (client_fd >= 0)
-		return true;
-
-	if (unrecoverableError)
-		std::cerr << "accept: " << std::strerror(errno) << std::endl;
-
-	return false;
+	return client_fd >= 0;
 }
 
 bool Server::setNonBlocking(int fd)

--- a/srcs/Server/ServerIn.cpp
+++ b/srcs/Server/ServerIn.cpp
@@ -1,7 +1,6 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-#include <cerrno>
 #include <sys/socket.h>
 
 static const std::size_t RECV_BUF_SIZE = 4096;
@@ -33,9 +32,7 @@ bool Server::isRecvSuccessful(ssize_t bytesReceived, int fd)
 
 	if (recvError)
 	{
-		bool unrecoverableError = (errno != EAGAIN && errno != EWOULDBLOCK);
-		if (unrecoverableError)
-			addToDisconnectList(fd);
+		addToDisconnectList(fd);
 		return false;
 	}
 	if (connectionClosed)

--- a/srcs/Server/ServerLoop.cpp
+++ b/srcs/Server/ServerLoop.cpp
@@ -1,6 +1,5 @@
 #include "Server.hpp"
 
-#include <cerrno>
 #include <cstring>
 #include <stdexcept>
 
@@ -22,14 +21,9 @@ void Server::loop()
 
 void Server::waitForEvents()
 {
-	int ready = -1;
-
-	while (ready < 0 && !_stop)
-	{
-		ready = poll(&_pfds[0], _pfds.size(), -1);
-		if (ready < 0 && errno != EINTR)
-			throw std::runtime_error("poll: " + std::string(std::strerror(errno)));
-	}
+	int ready = poll(&_pfds[0], _pfds.size(), -1);
+	if (ready < 0 && !_stop)
+		throw std::runtime_error("poll failed");
 }
 
 void Server::handlePollEvents()

--- a/srcs/Server/ServerOut.cpp
+++ b/srcs/Server/ServerOut.cpp
@@ -1,7 +1,6 @@
 #include "Server.hpp"
 #include "Client.hpp"
 
-#include <cerrno>
 #include <sys/socket.h>
 
 static int FLAGS_NONE = 0;
@@ -56,9 +55,7 @@ bool Server::isSendSuccessful(ssize_t bytesSent, int fd)
 
 	if (sendError)
 	{
-		bool unrecoverableError = (errno != EAGAIN && errno != EWOULDBLOCK);
-		if (unrecoverableError)
-			addToDisconnectList(fd);
+		addToDisconnectList(fd);
 		return false;
 	}
 	if (nothingSent)

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -29,6 +29,6 @@ int main(int argc, char** argv)
 	ircserv(argc, argv);
 	// (void)argc;
 	// (void)argv;
-	commandTest();
+	// commandTest();
 	return 0;
 }


### PR DESCRIPTION
## 変更点
errnoを使用せずにPOLLのフラグのみで動作をハンドリングするように変更。

```
POLLIN   → 読める（recv が EAGAIN を返さない）
POLLOUT  → 書ける（send が EAGAIN を返さない）
POLLERR  → エラー発生
POLLHUP  → 切断
POLLNVAL → 無効な fd
```

### その他変更点

・KICKコマンドの修正
・テストスクリプト追加