### PR TITLE
エラーメッセージを改善し、非ブロッキング設定の失敗を明示化

### DIFF
--- a/srcs/Server/ServerAccept.cpp
+++ b/srcs/Server/ServerAccept.cpp
@@ -43,7 +43,7 @@ bool Server::setNonBlocking(int fd)
 {
 	if (fcntl(fd, F_SETFL, O_NONBLOCK) < 0)
 	{
-		std::cerr << "fcntl: " << std::strerror(errno) << std::endl;
+		std::cerr << "fcntl: failed to set non-blocking" << std::endl;
 		return false;
 	}
 	return true;

--- a/srcs/Server/ServerSetup.cpp
+++ b/srcs/Server/ServerSetup.cpp
@@ -1,7 +1,5 @@
 #include "Server.hpp"
 
-#include <cerrno>
-#include <cstring>
 #include <iostream>
 #include <stdexcept>
 #include <arpa/inet.h>
@@ -35,10 +33,7 @@ void Server::setup()
 static int checkSyscall(int ret, const char* name)
 {
 	if (ret < 0)
-	{
-		int saved_errno = errno;
-		throw std::runtime_error(std::string(name) + ": " + std::strerror(saved_errno));
-	}
+		throw std::runtime_error(std::string(name) + " failed");
 	return ret;
 }
 


### PR DESCRIPTION
## 変更
エラーメッセージでerrnoを表示する仕様を変更。

### 理由
前回の変更で、errnoによるエラーハンドリングではなく
pollフラグによるハンドリングに変更した。
その際にerrnoを参照しない設計に変更したため、
エラーメッセージ上でerrnoを表示する実装を無くした。