### PR TITLE
Pingコマンドを追加し、Passコマンドに切断処理を追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ srcs/Command/Mode.cpp \
 srcs/Command/Nick.cpp \
 srcs/Command/Part.cpp \
 srcs/Command/Pass.cpp \
+srcs/Command/Ping.cpp \
 srcs/Command/Privmsg.cpp \
 srcs/Command/Quit.cpp \
 srcs/Command/Topic.cpp \

--- a/includes/command/Commands.hpp
+++ b/includes/command/Commands.hpp
@@ -13,5 +13,6 @@
 #include "Quit.hpp"
 #include "Part.hpp"
 #include "Cap.hpp"
+#include "Ping.hpp"
 
 #endif

--- a/includes/command/Ping.hpp
+++ b/includes/command/Ping.hpp
@@ -1,0 +1,12 @@
+#ifndef PING_HPP
+#define PING_HPP
+
+#include "ACommand.hpp"
+
+class Ping : public ACommand
+{
+	public:
+		void executeAction(Server& server, Client& client, int fd);
+};
+
+#endif

--- a/srcs/Command/Pass.cpp
+++ b/srcs/Command/Pass.cpp
@@ -17,6 +17,7 @@ void Pass::executeAction(Server& server, Client& client, int fd)
 	if (!server.checkPassword(params()[0]))
 	{
 		server.sendError(client, fd, "464", " :Password incorrect");
+		server.addToDisconnectList(fd);
 		return;
 	}
 	client.setPassAccepted();

--- a/srcs/Command/Ping.cpp
+++ b/srcs/Command/Ping.cpp
@@ -1,0 +1,14 @@
+#include "Ping.hpp"
+#include "Server.hpp"
+#include "Client.hpp"
+
+void Ping::executeAction(Server& server, Client& client, int fd)
+{
+	std::string token;
+	if (params().empty())
+		token = "ircserv";
+	else
+		token = params()[0];
+	client.appendToSendBuffer(":ircserv PONG ircserv :" + token + "\r\n");
+	server.setPollout(fd, true);
+}

--- a/srcs/Command/Privmsg.cpp
+++ b/srcs/Command/Privmsg.cpp
@@ -8,7 +8,6 @@
 static void sendForChannel(Server& server, Client& client, int fd, const std::string& channel_name, std::string message);
 static void sendForTarget(Server& server, Client& client, int fd, const std::string& target, std::string message);
 
-//    Parameters: <receiver>{,<receiver>} <text to be sent>
 void Privmsg::executeAction(Server& server, Client& client, int fd)
 {
 	if (!paramsErrorCheck(server, client, fd))

--- a/srcs/Server/ServerCommand.cpp
+++ b/srcs/Server/ServerCommand.cpp
@@ -25,6 +25,7 @@ void Server::initCommandMap()
 	_cmd_map["MODE"]    = new Mode();
 	_cmd_map["QUIT"]    = new Quit();
 	_cmd_map["PART"]    = new Part();
+	_cmd_map["PING"]    = new Ping();
 }
 
 void Server::handleCommand(Client& client, int fd, const std::string& command, const std::vector<std::string>& params)
@@ -34,7 +35,10 @@ void Server::handleCommand(Client& client, int fd, const std::string& command, c
 		return;
 
 	if (!client.isRegistered() && !isAllowedBeforeRegistration(command))
+	{
+		sendError(client, fd, "451", command + " :You have not registered");
 		return;
+	}
 
 	cmd->execute(*this, client, fd, params);
 }


### PR DESCRIPTION
## PINGの実装

PINGに対してPONGを返すだけ、
PINGに文字列があればそれも追加して返すのがルールなので
tokenとして受け取って返す。


## その他変更点

- PASSコマンドでクライアントがパスワードを間違えた場合に切断されなかった　->切断されるように修正。
- PRIVMSGファイルにあったコメントアウト削除。